### PR TITLE
Added initial support for open in ArcGIS

### DIFF
--- a/ckanext/geodatagov/helpers.py
+++ b/ckanext/geodatagov/helpers.py
@@ -168,6 +168,7 @@ types = {
         'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
         'text/csv', 'application/vnd.google-earth.kml+xml',
         'application/vnd.geo+json'),
+    'arcgis': ('esri rest')
 }
 
 def is_type_format(type, resource):
@@ -195,6 +196,9 @@ def is_plotly_format(resource):
 
 def is_cartodb_format(resource):
     return is_type_format('cartodb', resource)
+
+def is_arcgis_format(resource):
+    return is_type_format('arcgis', resource)
     
 def get_dynamic_menu():
     filename = os.path.join(os.path.dirname(__file__), 'dynamic_menu/menu.json')

--- a/ckanext/geodatagov/helpers.py
+++ b/ckanext/geodatagov/helpers.py
@@ -168,7 +168,7 @@ types = {
         'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
         'text/csv', 'application/vnd.google-earth.kml+xml',
         'application/vnd.geo+json'),
-    'arcgis': ('esri rest')
+    'arcgis': ('esri rest', )
 }
 
 def is_type_format(type, resource):

--- a/ckanext/geodatagov/plugins.py
+++ b/ckanext/geodatagov/plugins.py
@@ -407,6 +407,7 @@ class Demo(p.SingletonPlugin):
                 'is_map_viewer_format' : geodatagov_helpers.is_map_viewer_format,
                 'is_plotly_format': geodatagov_helpers.is_plotly_format,
                 'is_cartodb_format': geodatagov_helpers.is_cartodb_format,
+                'is_arcgis_format': geodatagov_helpers.is_arcgis_format,
                 'get_map_viewer_params': geodatagov_helpers.get_map_viewer_params,
                 'render_datetime_datagov': geodatagov_helpers.render_datetime_datagov,
                 'get_dynamic_menu': geodatagov_helpers.get_dynamic_menu,

--- a/ckanext/geodatagov/templates/package/snippets/resource_item.html
+++ b/ckanext/geodatagov/templates/package/snippets/resource_item.html
@@ -5,8 +5,10 @@
 {% set is_map_format = h.is_map_format(res) %}
 {% set is_cartodb_format = h.is_cartodb_format(res) %}
 {% set is_plotly_format = h.is_plotly_format(res) %}
+{% set is_arcgis_format = h.is_arcgis_format(res) %}
 {% set plotly_url = "https://plot.ly/external/" %}
 {% set cartodb_url = "http://oneclick.cartodb.com/" %}
+{% set arcgis_url = "http://www.arcgis.com/home/webmap/viewer.html" %}
 
 {% set filesize = res.size %}
 {% set tooltip = _("ZIP files may contain data and documentation in one or more formats. In Data.gov’s Geospatial catalog, most of the files are multi-part shapefiles.") if format == 'zip' %}
@@ -59,6 +61,15 @@
 	<a href="{{ resource_url }}" class="btn btn-primary"{% if is_web_format %} target="_blank"{% endif %} style="border-radius:4px;"> <i class="icon-globe"></i> {{ _('View Map') }} </a> 
 
 {% elif is_web_format %} 
+	{% if is_arcgis_format %}
+		<button class="btn btn-primary" data-toggle="dropdown" style="border-top-right-radius:0;border-bottom-right-radius:0">Open With</button>
+		<button class="btn btn-primary" data-toggle="dropdown" style="margin-left:0px;margin-right:10px;border-top-left-radius:0;border-bottom-left-radius:0">
+		<span class="caret" style="margin-top:0px;"></span><span class="sr-only">Toggle dropdown</span>
+		</button>
+		<ul class="dropdown-menu">
+		  <li class="arcgis"><a href="{{ arcgis_url }}?url={{ res.url }}"><span>ArcGIS</span></a></li>
+		</ul>
+	{% endif %}
 	<a href="{{ resource_url }}" class="btn btn-primary"{% if is_web_format %} target="_blank"{% endif %}> <i class="icon-external-link"></i> {{ _('Visit page') }} </a> 
 
 {% elif is_preview_format %} 


### PR DESCRIPTION
Added simple "Open in ArcGIS" for `esri rest` types. This is to the free and anonymous viewer. Optionally people can sign up for a free account but it's not required.

The free map viewer supports KML, CSV, WMS, etc. through the UI, but I'm checking if the `url=` parameter adds these as layers. 

Relates to https://github.com/GSA/data.gov/issues/602
