### PR TITLE
Changed the default text from "Web Page" to "Web Resource"

### DIFF
--- a/ckanext/geodatagov/plugins.py
+++ b/ckanext/geodatagov/plugins.py
@@ -373,7 +373,7 @@ def change_resource_details(resource):
     elif resource.get('name', '') in ['Unnamed resource', '', None]:
         if extension and not resource_format:
             resource['format'] = extension.upper()
-        resource['name'] = 'Web Page'
+        resource['name'] = 'Web Resource'
 
     if filename and not resource.get('description'):
         resource['description'] = filename


### PR DESCRIPTION
Hi,

This is another place that the default text needs to be changed to reflect "Web Resource". The "convert_resource_format" function in "https://github.com/GSA/ckanext-datagovtheme/blob/master/ckanext/datagovtheme/helpers.py" was already updated.

I also found a difference between two functions that I don't understand and wanted to verify they are correct. In both functions I see that an array is created from "RESOURCE_MAPPING.keys()".

In the "change_resource_details" function in this file the "format" seems to be set to the array value of "[0]" from the "RESOURCE_MAPPING" array and the "name" seems to be set to the array value of "[1]" from the "RESOURCE_MAPPING" array. Below is the function:

def change_resource_details(resource): 
     formats = RESOURCE_MAPPING.keys() 
     resource_format = resource.get('format', '').lower().lstrip('.') 
     filename, extension = get_filename_and_extension(resource) 
     if not resource_format: 
          resource_format = extension 
     if resource.get('name', '') in ['Unnamed resource', '', None]: 
          resource['no_real_name'] = True 
     if resource_format in formats: 
          resource['format'] = RESOURCE_MAPPING[resource_format][0] 
          if resource.get('name', '') in ['Unnamed resource', '', None]: 
               resource['name'] = RESOURCE_MAPPING[resource_format][1] 
               if filename: 
                    resource['name'] = resource['name'] 
     elif resource.get('name', '') in ['Unnamed resource', '', None]: 
          if extension and not resource_format: 
               resource['format'] = extension.upper() 
          resource['name'] = 'Web Page' 

In the "convert_resource_format" function in "https://github.com/GSA/ckanext-datagovtheme/blob/master/ckanext/datagovtheme/helpers.py" the "format" seems to be set to the array value of "[1]" from the "RESOURCE_MAPPING" array.

def convert_resource_format(format): 
     if format: format = format.lower() 
     formats = RESOURCE_MAPPING.keys() 
     if format in formats: 
          format = RESOURCE_MAPPING[format][1] 
     else: 
          format = 'Web Resource'
     return format

Questions:

Are both "RESOURCE_MAPPING" arrays the same, and, if so, are the values of "resource['format'] = RESOURCE_MAPPING[resource_format][0]" in the "change_resource_details" function and "format = RESOURCE_MAPPING[format][1]" in the "convert_resource_format" function the same?

Do both created "RESOURCE_MAPPING" arrays have values for both "format" and "name"?

Please let me know if there is anything else I can do to help.

Regards,

Dave