### PR TITLE
Query optimization for clean-deleted

### DIFF
--- a/ckanext/geodatagov/commands.py
+++ b/ckanext/geodatagov/commands.py
@@ -439,6 +439,7 @@ select DOCUUID, TITLE, OWNER, APPROVALSTATUS, HOST_URL, Protocol, PROTOCOL_TYPE,
         delete from resource where package_id in (select id from package where state = 'to_delete');
         delete from package_extra where package_id in (select id from package where state = 'to_delete');
         delete from member where table_id in (select id from package where state = 'to_delete');
+        delete from related_dataset where dataset_id in (select id from package where state = 'to_delete');
 
         delete from harvest_object_error hoe using harvest_object ho where ho.id = hoe.harvest_object_id and package_id  in (select id from package where state = 'to_delete');
         delete from harvest_object_extra hoe using harvest_object ho where ho.id = hoe.harvest_object_id and package_id  in (select id from package where state = 'to_delete');

--- a/ckanext/geodatagov/commands.py
+++ b/ckanext/geodatagov/commands.py
@@ -401,8 +401,12 @@ select DOCUUID, TITLE, OWNER, APPROVALSTATUS, HOST_URL, Protocol, PROTOCOL_TYPE,
         return harvestobj.text
 
     def clean_deleted(self):
-        print str(datetime.datetime.now()) + ' Starting delete'
-        sql = '''begin; update package set state = 'to_delete' where state <> 'active' and revision_id in (select id from revision where timestamp < now() - interval '1 day');
+        log.info('Starting delete for clean-deleted')
+        sql = '''begin;
+        update package set state = 'to_delete' where id in (
+          select id from package where state <> 'active'
+          limit 1000
+          );
         update package set state = 'to_delete' where owner_org is null;
         delete from package_role where package_id in (select id from package where state = 'to_delete' );
         delete from user_object_role where id not in (select user_object_role_id from package_role) and context = 'Package';
@@ -423,7 +427,7 @@ select DOCUUID, TITLE, OWNER, APPROVALSTATUS, HOST_URL, Protocol, PROTOCOL_TYPE,
 
         delete from package where id in (select id from package where state = 'to_delete'); commit;'''
         model.Session.execute(sql)
-        print str(datetime.datetime.now()) + ' Finished delete'
+        log.info('Finished delete for clean-deleted')
 
     # set([u'feed', u'webService', u'issued', u'modified', u'references', u'keyword', u'size', u'landingPage', u'title', u'temporal', u'theme', u'spatial', u'dataDictionary', u'description', u'format', u'granularity', u'accessLevel', u'accessURL', u'publisher', u'language', u'license', u'systemOfRecords', u'person', u'accrualPeriodicity', u'dataQuality', u'distribution', u'identifier', u'mbox'])
 

--- a/ckanext/geodatagov/commands.py
+++ b/ckanext/geodatagov/commands.py
@@ -34,7 +34,9 @@ from pylons import config
 from ckan import plugins as p
 from ckanext.geodatagov.model import MiscsFeed, MiscsTopicCSV
 
-log = logging.getLogger(__name__)
+# https://github.com/GSA/ckanext-geodatagov/issues/117
+log = logging.getLogger('ckanext.geodatagov')
+
 ckan_tmp_path = '/var/tmp/ckan'
 
 class GeoGovCommand(cli.CkanCommand):
@@ -1193,12 +1195,12 @@ select DOCUUID, TITLE, OWNER, APPROVALSTATUS, HOST_URL, Protocol, PROTOCOL_TYPE,
                 except KeyboardInterrupt:
                     raise
                 except:
-                    logging.error("Unexpected error: %s", sys.exc_info()[0])
+                    log.error("Unexpected error: %s", sys.exc_info()[0])
                 else:
                     datasets = query['results']
                     break
                 wait_time = 2 * attempts # wait longer with each failed attempt
-                logging.info('wait %s seconds before next attempt...' % wait_time)
+                log.info('wait %s seconds before next attempt...' % wait_time)
                 time.sleep(wait_time)
                 attempts += 1
 

--- a/ckanext/geodatagov/plugins.py
+++ b/ckanext/geodatagov/plugins.py
@@ -440,6 +440,7 @@ class Demo(p.SingletonPlugin):
         p.toolkit.add_template_directory(config, 'templates')
 
     def configure(self, config):
+        log.info('plugin initialized: %s', self.__class__.__name__)
         self.__class__.edit_url = config.get('saml2.user_edit')
 
 
@@ -653,4 +654,5 @@ class Miscs(p.SingletonPlugin):
 
     ## IConfigurable
     def configure(self, config):
+        log.info('plugin initialized: %s', self.__class__.__name__)
         geodatagovmodel.setup()


### PR DESCRIPTION
- Reduce the number of packages to operate at one time
- Avoid query on revision

The revision query is way too heavy. Almost every revision is going to be older
than yesterday, so you end up pulling the entire table into memory to compare
against the package table. May as well not use it at all.