### PR TITLE
Avoid error in no-request contexts during tests

### DIFF
--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -100,12 +100,20 @@ paster spatial initdb -c ../ckan/test-core.ini
 
 cd ..
 echo "-----------------------------------------------------------------"
+echo "Installing DataGovTheme"
+git clone https://github.com/GSA/ckanext-datagovtheme
+cd ckanext-datagovtheme
+git checkout master
+
+python setup.py develop
+
+cd ..
+echo "-----------------------------------------------------------------"
 echo "Installing ckanext-geodatagov and its requirements..."
 cd ckanext-geodatagov
 pip install -r pip-requirements.txt
 python setup.py develop
 
-echo "-----------------------------------------------------------------"
 echo "Moving test.ini into a subdir..."
 mkdir subdir
 mv test.ini subdir

--- a/ckanext/geodatagov/plugins.py
+++ b/ckanext/geodatagov/plugins.py
@@ -514,25 +514,32 @@ class Demo(p.SingletonPlugin):
 
         return pkg_dict
 
-    def before_search(self, pkg_dict):
+    def before_search(self, search_params):
 
-        fq = pkg_dict.get('fq', '')
-
-        if pkg_dict.get('sort') in (None, 'rank'):
-            pkg_dict['sort'] = 'views_recent desc'
+        fq = search_params.get('fq', '')
+        
+        if search_params.get('sort') in (None, 'rank'):
+            search_params['sort'] = 'views_recent desc'
 		
-        if pkg_dict.get('sort') in ('none'):
-            pkg_dict['sort'] = 'score desc, name asc'
+        if search_params.get('sort') in ('none'):
+            search_params['sort'] = 'score desc, name asc'
 
         # only show collections on bulk update page and when the facet is explictely added
-
         try:
-            if 'collection_package_id' not in fq and 'bulk_process' not in request.path:
-                pkg_dict['fq'] = fq + ' -collection_package_id:["" TO *]'
-        except Exception:
-            pass
-
-        return pkg_dict
+            path = request.path
+        except:
+            # when there is no requests we get a 
+            # TypeError: No object (name: request) has been registered for this thread
+            path = ''    
+        
+        if 'collection_package_id' not in fq and 'bulk_process' not in path:
+            log.info('Added FQ to collection_package_id')
+            fq += ' -collection_package_id:["" TO *]'            
+        else:
+            log.info('NOT Added FQ to collection_package_id')
+        
+        search_params['fq'] = fq
+        return search_params
 
 
     def after_show(self, context, data_dict):

--- a/test.ini
+++ b/test.ini
@@ -15,10 +15,6 @@ ckan.plugins = harvest geodatagov geodatagov_miscs z3950_harvester arcgis_harves
 [loggers]
 keys = root, ckan, sqlalchemy
 
-# Logging configuration
-[loggers]
-keys = root, ckan, sqlalchemy
-
 [handlers]
 keys = console
 


### PR DESCRIPTION
 - Fix an error to override `before_search` in context without a `request`.
 - Upgrade the CI environment by adding missing extensions

This branch is used to test 263 successfully.