### PR TITLE
include "name" as identifier to update packages

### DIFF
--- a/ckanext/geodatagov/logic.py
+++ b/ckanext/geodatagov/logic.py
@@ -334,7 +334,8 @@ def doi_update(context, data_dict):
 
 def update_action(context, data_dict):
     """ to run before update actions """
-    pkg_dict = p.toolkit.get_action('package_show')(context, {'id': data_dict['id']})
+    id_or_name = data_dict.get('id', data_dict.get('name'))
+    pkg_dict = p.toolkit.get_action('package_show')(context, {'id': id_or_name})
     if 'groups' not in data_dict:
         data_dict['groups'] = pkg_dict.get('groups', [])
     cats = {}


### PR DESCRIPTION
The update_action hook runs for **all** updated packages.
In some cases, we don't have a CKAN _id_. 
For example when we update a harvest source in our importer script we just have the _name_ of the source.
This simple PR allow this action to run using the _name_ instead of the _id_.
This is allowed by the `package_show` CKAN function.