### PR TITLE
Limit extras_rollup field building out of control

### DIFF
--- a/ckanext/geodatagov/commands.py
+++ b/ckanext/geodatagov/commands.py
@@ -35,7 +35,7 @@ from ckan import plugins as p
 from ckanext.geodatagov.model import MiscsFeed, MiscsTopicCSV
 
 if p.toolkit.check_ckan_version(max_version='2.3'):
-    from ckanext.harvest.model HarvestSystemInfo
+    from ckanext.harvest.model import HarvestSystemInfo
 
 # https://github.com/GSA/ckanext-geodatagov/issues/117
 log = logging.getLogger('ckanext.geodatagov')

--- a/ckanext/geodatagov/logic.py
+++ b/ckanext/geodatagov/logic.py
@@ -340,7 +340,7 @@ def update_action(context, data_dict):
     cats = {}
     for extra in pkg_dict.get('extras', []):
         if extra['key'].startswith('__category_tag_'):
-                cats[extra['key']] = extra['value']
+            cats[extra['key']] = extra['value']
     extras = data_dict.get('extras', [])
     for item in extras:
         if item['key'] in cats:
@@ -348,8 +348,10 @@ def update_action(context, data_dict):
     for cat in cats:
         extras.append({'key': cat, 'value': cats[cat]})
 
+
 # source ignored as queried diretly
-EXTRAS_ROLLUP_KEY_IGNORE = ["metadata-source", "tags"]
+EXTRAS_ROLLUP_KEY_IGNORE = ["metadata-source", "tags", "extras_rollup"]
+
 
 def rollup_save_action(context, data_dict):
     """ to run before create actions """
@@ -361,8 +363,12 @@ def rollup_save_action(context, data_dict):
         else:
             extras_rollup[extra['key']] = extra['value']
     if extras_rollup:
-        new_extras.append({'key': 'extras_rollup',
-                            'value': json.dumps(extras_rollup)})
+        extras_rollup_obj = [x for x in new_extras if x.key == 'extras_rollup']
+        if len(extras_rollup_obj) > 0:
+            extras_rollup_obj[0].values = json.dumps(extras_rollup)
+        else:
+            new_extras.append({'key': 'extras_rollup',
+                               'value': json.dumps(extras_rollup)})
     data_dict['extras'] = new_extras
 
 

--- a/ckanext/geodatagov/plugins.py
+++ b/ckanext/geodatagov/plugins.py
@@ -398,12 +398,11 @@ class Demo(p.SingletonPlugin):
     p.implements(p.IFacets, inherit=True)
     edit_url = None
 
-
     UPDATE_CATEGORY_ACTIONS = ['package_update', 'dataset_update']
     ROLLUP_SAVE_ACTIONS = ['package_create', 'dataset_create', 'package_update', 'dataset_update']
 
     # source ignored as queried diretly
-    EXTRAS_ROLLUP_KEY_IGNORE = ["metadata-source", "tags"]
+    EXTRAS_ROLLUP_KEY_IGNORE = ["metadata-source", "tags", "extras_rollup"]
 
     def before_action(self, action_name, context, data_dict):
         """ before_action is a hook in CKAN 2.3 for ALL actions
@@ -434,8 +433,12 @@ class Demo(p.SingletonPlugin):
                 else:
                     extras_rollup[extra['key']] = extra['value']
             if extras_rollup:
-                new_extras.append({'key': 'extras_rollup',
-                                   'value': json.dumps(extras_rollup)})
+                extras_rollup_obj = [x for x in new_extras if x.key == 'extras_rollup']
+                if len(extras_rollup_obj) > 0:
+                    extras_rollup_obj[0].values = json.dumps(extras_rollup)
+                else:
+                    new_extras.append({'key': 'extras_rollup',
+                                       'value': json.dumps(extras_rollup)})
             data_dict['extras'] = new_extras
 
     ## IConfigurer

--- a/ckanext/geodatagov/tests/test_waf.py
+++ b/ckanext/geodatagov/tests/test_waf.py
@@ -196,26 +196,25 @@ class TestWafHarvester(object):
         """ Test https://github.com/GSA/datagov-deploy/issues/2166 """
         datasets = self.get_datasets_from_waf1_sample()
         package = datasets[0]
-        extras_rollup = json.loads(package.extras['extras_rollup'])
+        pkg = package.as_dict()
+        extras = pkg['extras']
+        extras_rollup = json.loads(extras['extras_rollup'])
+        log.info("Rolled up at create: {}".format(extras_rollup))
 
         assert extras_rollup
-
-        # package.title = "Test change"
 
         log.info("extras_rollup package info: %s", package)
         sysadmin = Sysadmin(name='testUpdate')
         user_name = sysadmin['name'].encode('ascii')
         context = {'user': user_name}
+        new_extras = [{'key': key, 'value': value} for key, value in extras.iteritems()]
+
         get_action('package_update')(context, {
-            "id": package.name,
-            "title": "Test change"
+            "id": package.id,
+            "title": "Test change",
+            "extras": new_extras
         })
-
+        
         updated_package = model.Package.get(package.id)
-
-        log.info("Updated Package: %s", updated_package)
-
-        up_ext_rollup = json.loads(updated_package.extras['extras_rollup'])
-
-        for extra in up_ext_rollup:
-            assert extra.key != "extras_rollup"
+        extras_rollup = json.loads(updated_package.extras['extras_rollup'])
+        assert 'extras_rollup' not in extras_rollup


### PR DESCRIPTION
Related to [Extras Rollup issue with Catalog](https://github.com/GSA/datagov-deploy/issues/2166).

Fix is in place, tests are broken. Desire is to test normal harvest process, make an update, and validate package does not have nested extras_rollup object (current system can build new extras_rollup object with the old extras_rollup object inside the new one, and continue nesting for every change).