### PR TITLE
Allow sitemap generation for CKAN 2.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,22 +16,15 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Start CKAN
+          name: Build and test 
           command: |
             docker-compose build
             docker-compose up -d
-      - run:
-          name: install dockerize
-          command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-          environment:
-            DOCKERIZE_VERSION: v0.3.0
-      - run:
-          name: Wait for db
-          command: dockerize -wait http://localhost:5000/dataset -timeout 120s
-      - run:
-          name: Run Tests
-          command: |
+            sleep 40
+            docker-compose logs db
+            docker-compose logs ckan
             docker-compose exec ckan /bin/bash -c "nosetests --ckan --with-pylons=src_extensions/geodatagov/docker_test.ini src_extensions/geodatagov/"
+
   build_ckan_28:
     working_directory: ~/ckanext-geodatagov
     machine:

--- a/ckan-docker/Dockerfile
+++ b/ckan-docker/Dockerfile
@@ -1,11 +1,6 @@
 FROM openknowledge/ckan-dev:2.8
 
-MAINTAINER Your Name Here <you@example.com>
-
-RUN apk add py-cryptography
-
-# Fix shapely lib error. Install geos
-# TODO consider moving to Alpine>=3.11 or to Bionic
+RUN apk add py-cryptography libressl-dev musl-dev libffi-dev vim
 
 ADD http://download.osgeo.org/geos/geos-3.7.0.tar.bz2 /geos/geos.tar.bz2
 RUN tar xf /geos/geos.tar.bz2 -C /geos --strip-components=1
@@ -19,12 +14,9 @@ RUN cd ${SRC_DIR}/ckan && \
     git fetch gsa && \
     git checkout gsa/datagov-newcatalog
 
-RUN pip install -e git+https://github.com/ckan/ckanext-spatial#egg=ckanext-spatial && \
-    pip install -r https://raw.githubusercontent.com/ckan/ckanext-spatial/master/pip-requirements.txt && \
-    pip install -e git+https://github.com/ckan/ckanext-harvest.git#egg=ckanext-harvest && \
-    pip install -r https://raw.githubusercontent.com/ckan/ckanext-harvest/master/pip-requirements.txt && \
-    pip install -e git+https://github.com/GSA/ckanext-datajson.git#egg=ckanext-datajson && \
-    pip install -r https://raw.githubusercontent.com/GSA/ckanext-datajson/master/pip-requirements.txt && \
-    pip install -e git+https://github.com/GSA/ckanext-datagovtheme#egg=ckanext-datagovtheme && \
-    pip install -e git+https://github.com/GSA/ckanext-geodatagov.git#egg=ckanext-geodatagov && \
-    pip install -r https://raw.githubusercontent.com/GSA/ckanext-geodatagov/master/pip-requirements.txt  
+# Use reqs from catalog-next repo (and skip GSA/CKAN instalation)
+ADD https://raw.githubusercontent.com/GSA/catalog.data.gov/master/ckan/requirements.txt ${APP_DIR}/requirements.txt
+RUN sed -i '/GSA\/ckan\.git/d' ${APP_DIR}/requirements.txt
+
+RUN pip install --upgrade pip && \
+    pip install -r ${APP_DIR}/requirements.txt

--- a/ckanext/geodatagov/search.py
+++ b/ckanext/geodatagov/search.py
@@ -1,0 +1,50 @@
+import logging
+from ckan.common import config
+# from ckan.lib.search.common import make_connection
+# from ckan.lib.search.query import SearchQuery
+
+from ckan.lib.search import make_connection, PackageSearchQuery, SolrSettings
+
+
+log = logging.getLogger(__name__)
+
+
+class GeoPackageSearchQuery(PackageSearchQuery):
+    def get_count(self):
+        """
+        Return the count of all indexed packages.
+        """
+        query = "*:*"
+        fq = "+site_id:\"%s\" " % config.get('ckan.site_id')
+        fq += "+state:active "
+
+        conn = make_connection()
+        
+        try:
+            data = conn.search(query, fq=fq, rows=0)    
+        except Exception, e:
+            error = 'Error in GeoPackageSearchQuery.get_count: {}'.format(e)
+            log.error(error)
+            print(error)
+        
+        return data.hits
+
+    def get_paginated_entity_name_modtime(self, max_results=1000, start=0):
+        """
+        Return a list of the name and metadata_modified s of indexed packages.
+        """
+        query = "*:*"
+        fq = "+site_id:\"%s\" " % config.get('ckan.site_id')
+        fq += "+state:active "
+
+        conn = make_connection()
+        try:
+            data = conn.search(query, fq=fq, rows=max_results, fields='name,metadata_modified', start=start)
+        except Exception, e:
+            error = 'Error in GeoPackageSearchQuery.get_paginated_entity_name_modtime: {}'.format(e)
+            log.error(error)
+            print(error)
+        
+        return [{'name':r.get('name'),
+                 'metadata_modified': r.get('metadata_modified')} \
+                 for r in data.docs]

--- a/ckanext/geodatagov/search.py
+++ b/ckanext/geodatagov/search.py
@@ -39,7 +39,12 @@ class GeoPackageSearchQuery(PackageSearchQuery):
 
         conn = make_connection()
         try:
-            data = conn.search(query, fq=fq, rows=max_results, fields='name,metadata_modified', start=start)
+            data = conn.search(query,
+                               fq=fq,
+                               rows=max_results,
+                               fields='name,metadata_modified',
+                               start=start,
+                               sort='metadata_created asc')
         except Exception, e:
             error = 'Error in GeoPackageSearchQuery.get_paginated_entity_name_modtime: {}'.format(e)
             log.error(error)

--- a/ckanext/geodatagov/tests/test_sitemap_creation.py
+++ b/ckanext/geodatagov/tests/test_sitemap_creation.py
@@ -17,7 +17,7 @@ from ckanext.geodatagov.commands import GeoGovCommand
 log = logging.getLogger(__name__)
 
 
-class TestJSONExport(object):
+class TestSitemapExport(object):
 
     @classmethod
     def setup(cls):

--- a/ckanext/geodatagov/tests/test_sitemap_creation.py
+++ b/ckanext/geodatagov/tests/test_sitemap_creation.py
@@ -65,20 +65,26 @@ class TestSitemapExport(object):
             log.info('XML Root {}'.format(root))
             assert_equal(root.tag, '{http://www.sitemaps.org/schemas/sitemap/0.9}urlset')
             
-            names = [
-                self.dataset1['name'],
-                self.dataset2['name'],
-                self.dataset3['name'],
-                self.dataset4['name']
-            ]
-            
             prev_last_mod = ''
+
+            dataset1_found = False
+            dataset2_found = False
+            dataset3_found = False
+            dataset4_found = False
+            
             for url in root:
                 for child in url:
                     if child.tag == '{http://www.sitemaps.org/schemas/sitemap/0.9}loc':
                         dataset_url = child.text
                         dataset_name = dataset_url.split('/')[-1]
-                        assert_in(dataset_name, names)
+                        if dataset_name == self.dataset1['name']:
+                            dataset1_found = True
+                        elif dataset_name == self.dataset2['name']:
+                            dataset2_found = True
+                        elif dataset_name == self.dataset3['name']:
+                            dataset3_found = True
+                        elif dataset_name == self.dataset4['name']:
+                            dataset4_found = True
                         datasets += 1
                     elif child.tag == '{http://www.sitemaps.org/schemas/sitemap/0.9}lastmod':
                         last_mod = child.text
@@ -90,3 +96,7 @@ class TestSitemapExport(object):
 
         assert_equal(files, 1)
         assert datasets >= 4  # at least this four
+        assert dataset1_found
+        assert dataset2_found
+        assert dataset3_found
+        assert dataset4_found

--- a/ckanext/geodatagov/tests/test_sitemap_creation.py
+++ b/ckanext/geodatagov/tests/test_sitemap_creation.py
@@ -1,0 +1,53 @@
+import json
+import logging
+from nose.tools import assert_equal, assert_in
+from nose.plugins.skip import SkipTest
+try:
+    from ckan.tests.helpers import reset_db
+    from ckan.tests import factories
+    from ckan.common import config
+except ImportError:  # CKAN 2.3
+    from ckan.new_tests.helpers import reset_db
+    from ckan.new_tests import factories
+    from pylons import config
+
+from ckanext.geodatagov.commands import GeoGovCommand
+
+
+log = logging.getLogger(__name__)
+
+
+class TestJSONExport(object):
+
+    @classmethod
+    def setup(cls):
+        reset_db()
+        
+    def create_datasets(self):
+
+        organization = factories.Organization()
+        self.dataset1 = factories.Dataset(owner_org=organization['id'])
+        self.dataset2 = factories.Dataset(owner_org=organization['id'])
+        self.dataset3 = factories.Dataset(owner_org=organization['id'])
+        self.dataset4 = factories.Dataset(owner_org=organization['id'])
+        
+    def test_create_sitemap(self):
+        """ run sitemap-to-s3 and analyze results """
+        
+        self.create_datasets()
+
+        cmd = GeoGovCommand('test')
+        file_list = cmd.sitemap_to_s3(upload_to_s3=False, page_size=100, max_per_page=100)
+        
+        files = 0
+        for site_file in file_list:
+            files += 1
+
+            with open(site_file['path'], 'r') as f:
+                xml_data = f.read()
+                assert "/dataset/{}</loc>".format(self.dataset1['name']) in xml_data
+                assert "/dataset/{}</loc>".format(self.dataset2['name']) in xml_data
+                assert "/dataset/{}</loc>".format(self.dataset3['name']) in xml_data
+                assert "/dataset/{}</loc>".format(self.dataset4['name']) in xml_data
+        
+        assert files == 1


### PR DESCRIPTION
Related to [Multi#447](https://github.com/GSA/datagov-ckan-multi/issues/447) and [Multi#278](https://github.com/GSA/datagov-ckan-multi/issues/278)

This PR:
 - Move custom search function from CKAN 2.3 fork (278)
 - Allow `sitemap-to-s3` command to run without uploading to S3
 - Add tests to this XML files creation locally 
 - Preserve 2.3 compatibility