### PR TITLE
Avoid tags as extras before save a package

### DIFF
--- a/ckanext/geodatagov/tests/test_fix_packages.py
+++ b/ckanext/geodatagov/tests/test_fix_packages.py
@@ -8,11 +8,17 @@ try:
 except ImportError:
     from ckan.new_tests.helpers import reset_db
     from ckan.new_tests import factories
+from nose.plugins.skip import SkipTest
 
 log = logging.getLogger(__name__)
 
 
 class TestFixPkg(object):
+
+    @classmethod
+    def setup_class(cls):
+        if p.toolkit.check_ckan_version(max_version='2.3'):
+            raise SkipTest('Just for CKAN 2.8, we just change tags behaviour for 2.8')
 
     @classmethod
     def setup(cls):

--- a/ckanext/geodatagov/tests/test_fix_packages.py
+++ b/ckanext/geodatagov/tests/test_fix_packages.py
@@ -1,0 +1,50 @@
+
+import logging
+from nose.tools import assert_equal, assert_in
+from ckan import plugins as p
+try:
+    from ckan.tests.helpers import reset_db
+    from ckan.tests import factories
+except ImportError:
+    from ckan.new_tests.helpers import reset_db
+    from ckan.new_tests import factories
+
+log = logging.getLogger(__name__)
+
+
+class TestFixPkg(object):
+
+    @classmethod
+    def setup(cls):
+        reset_db()
+        cls.organization = factories.Organization() 
+
+    def test_fix_tags(self):
+        dataset_extras = [
+            {
+                "key": "tags",
+                "value": "tag01, tag02"
+            }
+        ]
+        dataset = factories.Dataset(
+            owner_org=self.organization['id'],
+            extras=dataset_extras)
+        
+        assert_in("tag01", [t['name'] for t in dataset['tags']])
+        assert_in("tag02", [t['name'] for t in dataset['tags']])
+    
+    def test_avoid_duplicated_tags(self):
+        dataset_extras = [
+            {
+                "key": "tags",
+                "value": "tag01, tag02"
+            }
+        ]
+        dataset = factories.Dataset(
+            owner_org=self.organization['id'],
+            extras=dataset_extras,
+            tags=[{'name': 'tag01'}])
+        
+        assert_equal(len(dataset['tags']), 2)
+        assert_in("tag01", [t['name'] for t in dataset['tags']])
+        assert_in("tag02", [t['name'] for t in dataset['tags']])

--- a/ckanext/geodatagov/tests/test_json_export.py
+++ b/ckanext/geodatagov/tests/test_json_export.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from nose.tools import assert_equal, assert_in
-from nose.plugins.skip import SkipTest
+
 try:
     from ckan.tests.helpers import reset_db
     from ckan.tests import factories

--- a/ckanext/geodatagov/tests/test_sitemap_creation.py
+++ b/ckanext/geodatagov/tests/test_sitemap_creation.py
@@ -3,7 +3,7 @@ import logging
 import xml.etree.ElementTree as ET
 
 from nose.tools import assert_equal, assert_in
-from nose.plugins.skip import SkipTest
+
 try:
     from ckan.tests.helpers import reset_db
     from ckan.tests import factories


### PR DESCRIPTION
Related to [Multi#472](https://github.com/GSA/datagov-ckan-multi/issues/472)

Before saving a dataset move back `tags` as regular field and no as an `extra`

Require more analysis. This is not a simple change
 - [ ] Review how this change affects to other extensions.