### PR TITLE
Start spatial data transformation to fit new specs

### DIFF
--- a/ckanext/geodatagov/tests/test_fix_spatial.py
+++ b/ckanext/geodatagov/tests/test_fix_spatial.py
@@ -1,0 +1,81 @@
+import os
+from nose.plugins.skip import SkipTest
+from nose.tools import assert_in, assert_true, assert_equal
+import ckan.model as model
+import ckan.plugins as p
+
+if p.toolkit.check_ckan_version(min_version='2.8'):
+    import ckan.tests.factories as factories
+    import ckan.tests.helpers as helpers
+    
+
+class TestSpatialField:
+
+    @classmethod
+    def setup_class(cls):
+        if not p.toolkit.check_ckan_version(min_version='2.8'):
+            raise SkipTest('Feature for CKAN 2.8')
+        helpers.reset_db()
+        cls.user = factories.Sysadmin(name='spatial_user')
+
+    def test_numeric_spatial_transformation(self):
+
+        old_geo = '10.0,0.0,15.0,5.0'
+
+        context = {'user': self.user['name'], 'ignore_auth':True}
+        pkg = {
+            'title': 'Spatial num',
+            'name': 'spatial-num',
+            'extras': [
+                {'key': 'spatial', 'value': old_geo}
+                ]
+        }
+        dataset = p.toolkit.get_action('package_create')(context, pkg)
+
+        expected_spatial = '{"type": "Polygon", "coordinates": [[[10.0, 0.0], [10.0, 5.0], [15.0, 5.0], [15.0, 0.0], [10.0, 0.0]]]}'
+    
+        spatial_extra_exists = False
+        for extra in dataset['extras']:
+            if extra['key'] == 'spatial':
+                spatial_extra_exists = True
+                assert_equal(extra['value'], expected_spatial)
+
+        assert_true(spatial_extra_exists)
+
+        result = helpers.call_action(
+            'package_search',
+            extras={'ext_bbox': '9,-1,16,4'})
+
+        assert_equal(result['count'], 1)
+        assert_equal(result['results'][0]['id'], dataset['id'])
+
+    def test_string_spatial_transformation(self):
+
+        old_geo = 'California'
+        # require locations table to be installed
+
+        context = {'user': self.user['name'], 'ignore_auth':True}
+        pkg = {
+            'title': 'Spatial String',
+            'name': 'spatial-str',
+            'extras': [
+                {'key': 'spatial', 'value': old_geo}
+                ]
+        }
+        dataset = p.toolkit.get_action('package_create')(context, pkg)
+
+        expected_spatial = '{"type":"Polygon","coordinates":[[[-124.3926,32.5358],[-124.3926,42.0022],[-114.1252,42.0022],[-114.1252,32.5358],[-124.3926,32.5358]]]}'
+        spatial_extra_exists = False
+        for extra in dataset['extras']:
+            if extra['key'] == 'spatial':
+                spatial_extra_exists = True
+                assert_equal(extra['value'], expected_spatial)
+
+        assert_true(spatial_extra_exists)
+
+        result = helpers.call_action(
+            'package_search',
+            extras={'ext_bbox': '-125,31,-113,43'})
+
+        assert_equal(result['count'], 1)
+        assert_equal(result['results'][0]['id'], dataset['id'])

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,11 +14,11 @@ services:
       - ckan_storage:/var/lib/ckan
       - .:/srv/app/src_extensions/geodatagov
   db:
-    image: ckan/postgresql
+    image: datagov/catalog.data.gov.db
     expose:
       - "5432"
   solr:
-    image: ckan/solr
+    image: datagov/catalog.data.gov.solr
     restart: always
     expose:
       - "8983"

--- a/test.ini
+++ b/test.ini
@@ -12,6 +12,8 @@ ckan.site_description = A test site for testing my CKAN extension
 ckan.plugins = stats geodatagov datagov_harvest ckan_harvester geodatagov_geoportal_harvester z3950_harvester arcgis_harvester waf_harvester_collection geodatagov_csw_harvester geodatagov_doc_harvester geodatagov_waf_harvester geodatagov_miscs spatial_metadata spatial_query resource_proxy spatial_harvest_metadata_api datagovtheme datajson_harvest
 ckan.legacy_templates = no
 ckan.spatial.validator.profiles = iso19139ngdc
+ckanext.spatial.search_backend = solr
+
 # Logging configuration
 [loggers]
 keys = root, ckan, sqlalchemy


### PR DESCRIPTION
Related to [Multi#523](https://github.com/GSA/datagov-ckan-multi/issues/523) and [Multi#332](https://github.com/GSA/datagov-ckan-multi/issues/332)

This PR:
 - Transform old spatial data in `ckanext-spatial` required format (GeoJSON)
 - Add test for old spatial data
 - Start using SOLR and DB images including the locations table