### PR TITLE
Fix error while loging

### DIFF
--- a/ckanext/geodatagov/logic.py
+++ b/ckanext/geodatagov/logic.py
@@ -6,7 +6,6 @@ import ckan.logic.schema as schema
 from ckan.logic.action import get as core_get
 import ckan.model as model
 import ckan.plugins as p
-from ckan import __version__ as ckan_version
 from ckanext.geodatagov.plugins import change_resource_details, split_tags
 from ckanext.geodatagov.harvesters.arcgis import _slugify
 from ckanext.harvest.model import HarvestJob, HarvestObject
@@ -468,7 +467,6 @@ def get_geo_from_string(location_name):
     
 def package_update(up_func, context, data_dict):
     """ before_package_update for CKAN 2.8 """
-    log.info('chained package_update {} {}'.format(ckan_version, data_dict['title']))
     preserve_category_tags(context, data_dict)
     rollup_save_action(context, data_dict)
     data_dict = fix_dataset(data_dict)
@@ -477,7 +475,6 @@ def package_update(up_func, context, data_dict):
 
 def package_create(up_func, context, data_dict):
     """ before_package_create for CKAN 2.8 """
-    log.info('chained package_create {} {}'.format(ckan_version, data_dict['title']))
     rollup_save_action(context, data_dict)
     data_dict = fix_dataset(data_dict)
     return up_func(context, data_dict)


### PR DESCRIPTION
Single PR after discovering error while logging

```
Traceback (most recent call last):
  File "/usr/bin/ckan", line 45, in <module>
    load_entry_point('PasteScript', 'console_scripts', 'paster')()
  File "/usr/lib/ckan/lib/python2.7/site-packages/paste/script/command.py", line 102, in run
    invoke(command, command_name, options, args[1:])
  File "/usr/lib/ckan/lib/python2.7/site-packages/paste/script/command.py", line 141, in invoke
    exit_code = runner.run(args)
  File "/usr/lib/ckan/lib/python2.7/site-packages/paste/script/command.py", line 236, in run
    result = self.command()
  File "/usr/lib/ckan-new/src/ckanext-harvest/ckanext/harvest/commands/harvester.py", line 237, in command
    utils.fetch_consumer()
  File "/usr/lib/ckan-new/src/ckanext-harvest/ckanext/harvest/utils.py", line 351, in fetch_consumer
    fetch_callback(consumer, method, header, body)
  File "/usr/lib/ckan-new/src/ckanext-harvest/ckanext/harvest/queue.py", line 483, in fetch_callback
    fetch_and_import_stages(harvester, obj)
  File "/usr/lib/ckan-new/src/ckanext-harvest/ckanext/harvest/queue.py", line 501, in fetch_and_import_stages
    success_import = harvester.import_stage(obj)
  File "/usr/lib/ckan-new/src/ckanext-spatial/ckanext/spatial/harvesters/base.py", line 609, in import_stage
    package_id = p.toolkit.get_action('package_create')(context, package_dict)
  File "/usr/lib/ckan-new/src/ckan/ckan/logic/__init__.py", line 467, in wrapped
    result = _action(context, data_dict, **kw)
  File "/usr/lib/ckan-new/src/ckanext-geodatagov/ckanext/geodatagov/logic.py", line 480, in package_create
    log.info('chained package_create {} {}'.format(ckan_version, data_dict['title']))
UnicodeEncodeError: 'ascii' codec can't encode character u'\x93' in position 33: ordinal not in range(128)
```
