### PR TITLE
Update requirements for upstream acceptance of fork

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 -e git+https://github.com/GSA/ckanext-datajson.git@a3dfe6bc183022572092ee572e557270701950a4#egg=ckanext-datajson
 -e git+https://github.com/nickumia-reisys/ckanext-harvest.git@9d1f647d247c16b6c3acba26e321e9500cafb18c#egg=ckanext-harvest
 -e git+https://github.com/GSA/ckanext-spatial.git@93c430ffc36ba7e306652fd511efd0d1e7081381#egg=ckanext-spatial
--e git+https://github.com/danizen/PyZ3950.git#egg=PyZ3950
+-e git+https://github.com/asl2/PyZ3950.git#egg=PyZ3950
 -e git+https://github.com/nickumia-reisys/werkzeug@e1f6527604ab30e4b46b5430a5fb97e7a7055cd7#egg=werkzeug
 boto
 ckantoolkit==0.0.3


### PR DESCRIPTION
The PyZ3950 repo was originally not py3-compatible so a fork was used that had implemented the py3 upgrade.  The upgrade has be accepted and the trail can be followed [here](https://github.com/GSA/datagov-ckan-multi/issues/576).  

I think we should leave this PR open to fix py3 bugs and do additional py3 cleanup during the deployment of this extension.