### PR TITLE
Update for getting source info

### DIFF
--- a/ckanext/geodatagov/templates/templates_2_8/source/geodatagov_source_form.html
+++ b/ckanext/geodatagov/templates/templates_2_8/source/geodatagov_source_form.html
@@ -50,7 +50,7 @@
 
 </fieldset>
 
-{% set private_datasets = source_config.get('private_datasets') or data.private_datasets %}
+{% set private_datasets = data.private_datasets or source_config.get('private_datasets') %}
 
 <div class="control-group form-group">
   <label for="field-private_datasets" class="control-label">{{ _('Dataset visibility') }}</label>

--- a/ckanext/geodatagov/templates/templates_new/source/geodatagov_source_form.html
+++ b/ckanext/geodatagov/templates/templates_new/source/geodatagov_source_form.html
@@ -50,7 +50,7 @@
 
 </fieldset>
 
-{% set private_datasets = source_config.get('private_datasets') or data.private_datasets %}
+{% set private_datasets = data.private_datasets or source_config.get('private_datasets') %}
 
 <div class="control-group form-group">
   <label for="field-private_datasets" class="control-label">{{ _('Dataset visibility') }}</label>


### PR DESCRIPTION
This fix does pull the correct source info.
The data is being set properly, but this will allow it to display
properly.

Related to https://github.com/GSA/datagov-deploy/issues/897