### PR TITLE
Track Ply as requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ jsonschema==2.4.0
 OWSLib==0.18.0
 # paste
 pika
-ply==3.4
 pyOpenSSL
 pyproj==2.6.1
 pyyaml==5.4

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='ckanext-geodatagov',
-    version='0.1.0',
+    version='0.1.1',
     description="",
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -30,7 +30,9 @@ setup(
         # -*- Extra requirements: -*-
         'ckanext-datagovtheme',
         'ckanext-datajson',
-        'boto'
+        'boto',
+        # 'ply==3.4',
+        'ply',
     ],
     setup_requires=['wheel'],
     entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,7 @@ setup(
         'ckanext-datagovtheme',
         'ckanext-datajson',
         'boto',
-        # 'ply==3.4',
-        'ply',
+        'ply>=3.4',
     ],
     setup_requires=['wheel'],
     entry_points="""


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/3414
- https://github.com/GSA/catalog.data.gov/pull/493

Changes:
- `ply` is a ckanext-geodatagov requirement
- `ply` does not need to be pinned.