### PR TITLE
apparently 0.1.3 was published in July?

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ Related to [LINK TO ISSUE]
 
 ## PR TASKS
 
-- [ ] The actual code changes
-- [ ] Tests written and passed
+- [ ] The actual code changes.
+- [ ] Tests written and passed.
 - [ ] Any changes to docs?
-- [ ] Bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/1b1bad0b2ff06112e18c7f4f4fb1143baec1266a/setup.py#L13)
+- [ ] Bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/1b1bad0b2ff06112e18c7f4f4fb1143baec1266a/setup.py#L13) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,14 @@
-# PR
+# Pull Request
 
 Related to [LINK TO ISSUE]
 
-- [ ] bumped version number in
-  [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/1b1bad0b2ff06112e18c7f4f4fb1143baec1266a/setup.py#L13)
+## About
+
+<!-- any pertinent notes -->
+
+## PR TASKS
+
+- [ ] The actual code changes
+- [ ] Tests written and passed
+- [ ] Any changes to docs?
+- [ ] Bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/1b1bad0b2ff06112e18c7f4f4fb1143baec1266a/setup.py#L13)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='ckanext-geodatagov',
-    version='0.1.3',
+    version='0.1.4',
     description="",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
# PR

Related to https://github.com/GSA/data.gov/issues/3648

Weird, looks like [0.1.3](https://pypi.org/project/ckanext-geodatagov/0.1.3/) is already out there. 

- [x] bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/1b1bad0b2ff06112e18c7f4f4fb1143baec1266a/setup.py#L13)
