### PR TITLE
DB Solr Sync - Defer commit

### DIFF
--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -299,8 +299,7 @@ def db_solr_sync(dryrun, cleanup_solr, update_solr):
                 pkg_dict = logic.get_action('package_show')(context, {'id': id})
                 try:
                     if not dryrun:
-                        package_index.remove_dict(pkg_dict)
-                        package_index.insert_dict(pkg_dict)
+                        package_index.update_dict(pkg_dict, True)
                 except Exception as e:
                     log.error(u'Error while rebuild index %s: %s' % (id, repr(e)))
     else:

--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -4,7 +4,6 @@ import json
 import logging
 
 import boto3
-import ckan.logic as logic
 import ckan.model as model
 import click
 from botocore.exceptions import ClientError
@@ -251,7 +250,6 @@ def db_solr_sync(dryrun, cleanup_solr, update_solr):
         log.info('Starting dryrun to update index.')
 
     package_index = index_for(model.Package)
-    context = {'model': model, 'ignore_auth': True, 'validate': False, 'use_cache': False}
 
     # get active packages from DB
     active_package = [(r[0], r[1].replace(microsecond=0)) for r in model.Session.query(model.Package.id,
@@ -275,7 +273,7 @@ def db_solr_sync(dryrun, cleanup_solr, update_solr):
             work_list[id] = "db"
 
     both = cleanup_solr == update_solr
-    set_cleanup = {i if work_list[i] == "solr" else None for i in work_list } - {None}
+    set_cleanup = {i if work_list[i] == "solr" else None for i in work_list} - {None}
     set_update = work_list.keys() - set_cleanup
     log.info(f"{len(set_cleanup)} packages need to be removed from Solr")
     log.info(f"{len(set_update)} packages need to be updated/added to Solr")
@@ -291,7 +289,7 @@ def db_solr_sync(dryrun, cleanup_solr, update_solr):
         log.info('Finished cleaning solr entries.')
 
     if not dryrun and set_update and (update_solr or both):
-        log.info(f"rebuilding indexes\n")
+        log.info("rebuilding indexes\n")
         try:
             rebuild(package_ids=set_update, defer_commit=True)
         except Exception as e:

--- a/ckanext/geodatagov/tests/test_db_solr_sync.py
+++ b/ckanext/geodatagov/tests/test_db_solr_sync.py
@@ -92,10 +92,6 @@ class TestSolrDBSync(object):
         # check successful cli run
         assert cli_result.exit_code == 0
 
-        # For the tests, we need the commits to happen
-        # On production, deferring is okay
-        model.Session.commit()
-
         final_db = get_active_db_ids()
         final_solr = get_all_solr_ids()
 

--- a/ckanext/geodatagov/tests/test_db_solr_sync.py
+++ b/ckanext/geodatagov/tests/test_db_solr_sync.py
@@ -92,6 +92,10 @@ class TestSolrDBSync(object):
         # check successful cli run
         assert cli_result.exit_code == 0
 
+        # For the tests, we need the commits to happen
+        # On production, deferring is okay
+        model.Session.commit()
+
         final_db = get_active_db_ids()
         final_solr = get_all_solr_ids()
 


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/3985
- https://github.com/GSA/data.gov/issues/2213

This should be more efficient 🦅 

It takes too long to update `package_id` one by one. Use `rebuild` function, take `package_ids` with defer_commit as True. It should speed things up.
