### PR TITLE
add custom command ckan geodatagov tracking-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,19 @@ environment variable.
 
     $ make CKAN_VERSION=2.9 test
 
+### Command line interface
+
+The following operations can be run from the command line as described underneath::
+
+      geodatagov sitemap-to-s3 [{upload_to_s3}] [{page_size}] [{max_per_page}]
+        - Generates sitemap and uploads to s3
+
+      geodatagov db-solr-sync [{dryrun}] [{cleanup_solr}] [{update_solr}]
+        - DB Solr sync. 
+
+      geodatagov tracking-update [{start_date}]
+        - ckan tracking update with customized options and output
+
 ## Credit / Copying
 
 Original work written by the HealthData.gov team. It has been modified in support of Data.gov.

--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -369,7 +369,8 @@ def update_tracking_solr(engine, start_date):
     )
 
     context = {'model': model, 'ignore_auth': True, 'validate': False,
-        'use_cache': False}
+               'use_cache': False}
+    package_index = index_for(model.Package)
     quiet = False
     force = True
     defer_commit = True
@@ -377,26 +378,26 @@ def update_tracking_solr(engine, start_date):
         if not quiet:
             sys.stdout.write(
                 "\rIndexing dataset {0}/{1}".format(
-                    counter +1, total)
+                    counter + 1, total)
             )
             sys.stdout.flush()
         try:
             package_index.update_dict(
-                logic.get_action('package_show')(context,
+                logic.get_action('package_show')(
+                    context,
                     {'id': pkg_id}
                 ),
                 defer_commit
             )
         except Exception as e:
             log.error(u'Error while indexing dataset %s: %s' %
-                        (pkg_id, repr(e)))
+                      (pkg_id, repr(e)))
             if force:
                 log.error(text_traceback())
                 continue
             else:
                 raise
 
-    package_index = index_for(model.Package)
     package_index.commit()
 
 

--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -353,6 +353,7 @@ def test_command():
 @geodatagov.command()
 @click.argument(u'start_date', required=False)
 def tracking_update(start_date: Optional[str]):
+    """ckan tracking update with customized options and output"""
     engine = model.meta.engine
     assert engine
     update_all(engine, start_date)

--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -2,7 +2,6 @@ import base64
 import datetime
 import hashlib
 import sys
-import io
 import json
 import logging
 import warnings

--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -1,15 +1,20 @@
 import base64
 import datetime
 import hashlib
+import sys
 import io
 import json
 import logging
-
+import warnings
+import cgitb
 import boto3
-import ckan.model as model
 import click
 from botocore.config import Config
 from botocore.exceptions import ClientError
+from typing import Optional
+
+import ckan.model as model
+import ckan.logic as logic
 from ckan.common import config
 from ckan.lib.search import rebuild
 from ckan.lib.search.common import make_connection
@@ -311,6 +316,97 @@ def test_command():
     ''' Basic cli command with normal result '''
     print("This is a good test!")
     return True
+
+
+@geodatagov.command()
+@click.argument(u'start_date', required=False)
+def tracking_update(start_date: Optional[str]):
+    engine = model.meta.engine
+    assert engine
+    update_all(engine, start_date)
+
+
+def update_all(engine, start_date=None):
+    from ckan.cli.tracking import update_tracking
+    if start_date:
+        start_date = datetime.datetime.strptime(start_date, u'%Y-%m-%d')
+    else:
+        # No date given. See when we last have data for and get data
+        # from 2 days before then in case new data is available.
+        # If no date here then use 2011-01-01 as the start date
+        sql = u'''SELECT tracking_date from tracking_summary
+                    ORDER BY tracking_date DESC LIMIT 1;'''
+        result = engine.execute(sql).fetchall()
+        if result:
+            start_date = result[0][u'tracking_date']
+            start_date += datetime.timedelta(-2)
+            # convert date to datetime
+            combine = datetime.datetime.combine
+            start_date = combine(start_date, datetime.time(0))
+        else:
+            start_date = datetime.datetime(2011, 1, 1)
+    start_date_solrsync = start_date
+    end_date = datetime.datetime.now()
+    while start_date < end_date:
+        stop_date = start_date + datetime.timedelta(1)
+        update_tracking(engine, start_date)
+        click.echo(u'tracking updated for {}'.format(start_date))
+        start_date = stop_date
+    update_tracking_solr(engine, start_date_solrsync)
+
+
+def update_tracking_solr(engine, start_date):
+    sql = u'''SELECT distinct(package_id) FROM tracking_summary
+            where package_id!='~~not~found~~'
+            and tracking_date >= %s;'''
+    results = engine.execute(sql, start_date)
+    package_ids = set()
+    for row in results:
+        package_ids.add(row[u'package_id'])
+    total = len(package_ids)
+    click.echo(u'{} package index{} to be rebuilt starting from {}'.format(
+        total, u'' if total < 2 else u'es', start_date)
+    )
+
+    context = {'model': model, 'ignore_auth': True, 'validate': False,
+        'use_cache': False}
+    quiet = False
+    force = True
+    defer_commit = True
+    for counter, pkg_id in enumerate(package_ids):
+        if not quiet:
+            sys.stdout.write(
+                "\rIndexing dataset {0}/{1}".format(
+                    counter +1, total)
+            )
+            sys.stdout.flush()
+        try:
+            package_index.update_dict(
+                logic.get_action('package_show')(context,
+                    {'id': pkg_id}
+                ),
+                defer_commit
+            )
+        except Exception as e:
+            log.error(u'Error while indexing dataset %s: %s' %
+                        (pkg_id, repr(e)))
+            if force:
+                log.error(text_traceback())
+                continue
+            else:
+                raise
+
+    package_index = index_for(model.Package)
+    package_index.commit()
+
+
+def text_traceback():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = 'the original traceback:'.join(
+            cgitb.text(sys.exc_info()).split('the original traceback:')[1:]
+        ).strip()
+    return res
 
 
 @datagovs3.command()

--- a/ckanext/geodatagov/tests/test_tracking.py
+++ b/ckanext/geodatagov/tests/test_tracking.py
@@ -1,0 +1,56 @@
+import logging
+
+import pytest
+import ckan.model as model
+from ckan.tests import factories, helpers
+from ckan.tests.helpers import reset_db
+from click.testing import CliRunner
+
+import ckanext.geodatagov.cli as cli
+
+log = logging.getLogger(__name__)
+
+
+class TestTracking(object):
+    @classmethod
+    def setup_class(cls):
+        reset_db()
+
+    def create_datasets(self):
+
+        organization = factories.Organization()
+        self.dataset = factories.Dataset(owner_org=organization["id"])
+
+        # total view should be 0 for a new dataset
+        package = helpers.call_action("package_show", id=self.dataset["id"], include_tracking=True)
+        assert package['tracking_summary']['total'] == 0
+
+        # insert two raw tracking data
+        sql = (
+            "INSERT INTO tracking_raw (user_key, url, tracking_type, access_timestamp) VALUES"
+            "('aaa','/dataset/{0}','page','2020-10-10'),"
+            "('bbb','/dataset/{0}','page','2021-11-11')"
+        ).format(self.dataset["name"])
+
+        model.Session.execute(sql)
+        model.Session.commit()
+
+    @pytest.fixture
+    def cli_result(self):
+        self.create_datasets()
+
+        runner = CliRunner()
+        raw_cli_output = runner.invoke(
+            cli.tracking_update,
+            args=[],
+        )
+
+        return raw_cli_output
+
+    def test_tracking_data_in_package_show(self, cli_result):
+
+        assert cli_result.exit_code == 0
+
+        pacakge = helpers.call_action("package_show", id=self.dataset["id"], include_tracking=True)
+        assert pacakge['tracking_summary']['total'] == 2
+        assert pacakge['tracking_summary']['recent'] == 1

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name="ckanext-geodatagov",
-    version="0.1.12",
+    version="0.1.13",
     description="",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
# Pull Request

Related to https://github.com/GSA/data.gov/issues/1479
## About

Copied from core `ckan tracking update` command, but used custom rebuild command to achieve
- better logging,
- faster solr indexing with defer commit,
- ignore index error and continue

TODO: make it resume-able. Without it, It will be difficult to impossible to fix some error due to Solr index glitches when updating large amount of data.

## PR TASKS

- [x] The actual code changes.
- [x] Tests written and passed.
- [x] Any changes to docs?
- [x] Bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/1b1bad0b2ff06112e18c7f4f4fb1143baec1266a/setup.py#L13) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).
