### PR TITLE
Optimize db solr sync to speed up the deletion of large amount solr indexes

### DIFF
--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -274,8 +274,13 @@ def delete_packages(package_ids):
     commit = False
     conn = make_connection()
     for id in package_ids:
-        query = "+%s:%s AND +(id:\"%s\" OR name:\"%s\") AND +site_id:\"%s\"" % \
-                (TYPE_FIELD, PACKAGE_TYPE, id, id, config.get('ckan.site_id'))
+        query = '+%s:%s AND +(id:"%s" OR name:"%s") AND +site_id:"%s"' % (
+            TYPE_FIELD,
+            PACKAGE_TYPE,
+            id,
+            id,
+            config.get("ckan.site_id"),
+        )
         try:
             log.info(f"deleting index with {id} \n")
             conn.delete(q=query, commit=commit)

--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -270,7 +270,7 @@ def get_all_entity_ids_and_date(max_results: int = 1000):
 
 def delete_packages(package_ids):
     """
-    Please update this
+    Delete solr indexes for a list of packages and defer the commit to the end.
     """
     TYPE_FIELD = "entity_type"
     PACKAGE_TYPE = "package"

--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -269,23 +269,21 @@ def get_all_entity_ids_and_date(max_results: int = 1000):
 
 
 def delete_packages(package_ids):
+    """
+    Please update this
+    """
     TYPE_FIELD = "entity_type"
     PACKAGE_TYPE = "package"
     commit = False
     conn = make_connection()
+    site_id = config.get("ckan.site_id")
     for id in package_ids:
-        query = '+%s:%s AND +(id:"%s" OR name:"%s") AND +site_id:"%s"' % (
-            TYPE_FIELD,
-            PACKAGE_TYPE,
-            id,
-            id,
-            config.get("ckan.site_id"),
-        )
+        query = f'+{TYPE_FIELD}:{PACKAGE_TYPE} AND +(id:"{id}" OR name:"{id}") AND +site_id:"{site_id}"'
         try:
-            log.info(f"deleting index with {id} \n")
+            log.info(f"deleting index with {id}")
             conn.delete(q=query, commit=commit)
         except Exception as e:
-            log.error("Error while delete index %s: %s" % (id, repr(e)))
+            log.error(f"Error while delete index {id}: {repr(e)}")
     conn.commit(waitSearcher=False)
 
 
@@ -340,13 +338,13 @@ def db_solr_sync(dryrun, cleanup_solr, update_solr):
     log.info(f"{len(set_update)} packages need to be updated/added to Solr")
 
     if not dryrun and set_cleanup and (cleanup_solr or both):
-        log.info("Deleting indexes\n")
+        log.info("Deleting indexes")
         delete_packages(set_cleanup)
         package_index.commit()
         log.info("Finished cleaning solr entries.")
 
     if not dryrun and set_update and (update_solr or both):
-        log.info("Rebuilding indexes\n")
+        log.info("Rebuilding indexes")
         try:
             rebuild(package_ids=set_update, defer_commit=True)
         except Exception as e:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name="ckanext-geodatagov",
-    version="0.1.11",
+    version="0.1.12",
     description="",
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/test.ini
+++ b/test.ini
@@ -6,7 +6,7 @@ smtp_server = localhost
 error_email_from = paste@localhost
 
 [app:main]
-use = config:../../src/ckan/test-core.ini
+use = config:/srv/app/src/ckan/test-core.ini
 ckan.site_title = My Test CKAN Site
 ckan.site_description = A test site for testing my CKAN extension
 ckan.plugins = stats geodatagov datagov_harvest ckan_harvester geodatagov_geoportal_harvester z3950_harvester arcgis_harvester waf_harvester_collection geodatagov_csw_harvester geodatagov_doc_harvester geodatagov_waf_harvester geodatagov_miscs spatial_metadata spatial_query resource_proxy spatial_harvest_metadata_api datajson_harvest envvars

--- a/test.ini
+++ b/test.ini
@@ -6,7 +6,7 @@ smtp_server = localhost
 error_email_from = paste@localhost
 
 [app:main]
-use = config:/srv/app/src/ckan/test-core.ini
+use = config:../../src/ckan/test-core.ini
 ckan.site_title = My Test CKAN Site
 ckan.site_description = A test site for testing my CKAN extension
 ckan.plugins = stats geodatagov datagov_harvest ckan_harvester geodatagov_geoportal_harvester z3950_harvester arcgis_harvester waf_harvester_collection geodatagov_csw_harvester geodatagov_doc_harvester geodatagov_waf_harvester geodatagov_miscs spatial_metadata spatial_query resource_proxy spatial_harvest_metadata_api datajson_harvest envvars


### PR DESCRIPTION
Related to 
- https://github.com/GSA/data.gov/issues/4007

To speed up the solr index deletion for large set, did following changes:
- Add new function to delete indexes in solr with one connection and commit at the end.
- Pass list of package ids to the new delete function to speed up. 

## PR TASKS

- [x] The actual code changes.
- [x] Tests written and passed.
- [ ] Any changes to docs?
- [x] Bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/1b1bad0b2ff06112e18c7f4f4fb1143baec1266a/setup.py#L13) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).
