### PR TITLE
Fix/sitename urls

### DIFF
--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -67,7 +67,7 @@ class Sitemap:
         )
         for pkg in pkgs:
             self.xml += "    <url>\n"
-            self.xml += f"        <loc>{config.get('ckan.site_url')}/dataset/{pkg.get('name')}</loc>\n"
+            self.xml += f"        <loc>https://catalog.data.gov/dataset/{pkg.get('name')}</loc>\n"
             self.xml += f"        <lastmod>{pkg.get('metadata_modified').strftime('%Y-%m-%d')}</lastmod>\n"
             self.xml += "    </url>\n"
 

--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -1,19 +1,19 @@
 import base64
+import cgitb
 import datetime
 import hashlib
-import sys
 import json
 import logging
-import warnings
-import cgitb
+import sys
 import tempfile
-import boto3
-import click
-from botocore.config import Config
+import warnings
 from typing import Optional
 
-import ckan.model as model
+import boto3
 import ckan.logic as logic
+import ckan.model as model
+import click
+from botocore.config import Config
 from ckan.common import config
 from ckan.lib.search import rebuild
 from ckan.lib.search.common import make_connection
@@ -366,7 +366,7 @@ def test_command():
 
 
 @geodatagov.command()
-@click.argument(u'start_date', required=False)
+@click.argument("start_date", required=False)
 def tracking_update(start_date: Optional[str]):
     """ckan tracking update with customized options and output"""
     engine = model.meta.engine
@@ -376,17 +376,18 @@ def tracking_update(start_date: Optional[str]):
 
 def update_all(engine, start_date=None):
     from ckan.cli.tracking import update_tracking
+
     if start_date:
-        start_date = datetime.datetime.strptime(start_date, u'%Y-%m-%d')
+        start_date = datetime.datetime.strptime(start_date, "%Y-%m-%d")
     else:
         # No date given. See when we last have data for and get data
         # from 2 days before then in case new data is available.
         # If no date here then use 2011-01-01 as the start date
-        sql = u'''SELECT tracking_date from tracking_summary
-                    ORDER BY tracking_date DESC LIMIT 1;'''
+        sql = """SELECT tracking_date from tracking_summary
+                    ORDER BY tracking_date DESC LIMIT 1;"""
         result = engine.execute(sql).fetchall()
         if result:
-            start_date = result[0][u'tracking_date']
+            start_date = result[0]["tracking_date"]
             start_date += datetime.timedelta(-2)
             # convert date to datetime
             combine = datetime.datetime.combine
@@ -398,46 +399,45 @@ def update_all(engine, start_date=None):
     while start_date < end_date:
         stop_date = start_date + datetime.timedelta(1)
         update_tracking(engine, start_date)
-        click.echo(u'tracking updated for {}'.format(start_date))
+        click.echo("tracking updated for {}".format(start_date))
         start_date = stop_date
     update_tracking_solr(engine, start_date_solrsync)
 
 
 def update_tracking_solr(engine, start_date):
-    sql = u'''SELECT distinct(package_id) FROM tracking_summary
+    sql = """SELECT distinct(package_id) FROM tracking_summary
             where package_id!='~~not~found~~'
-            and tracking_date >= %s;'''
+            and tracking_date >= %s;"""
     results = engine.execute(sql, start_date)
     package_ids = set()
     for row in results:
-        package_ids.add(row[u'package_id'])
+        package_ids.add(row["package_id"])
     total = len(package_ids)
-    click.echo(u'{} package index{} to be rebuilt starting from {}'.format(
-        total, u'' if total < 2 else u'es', start_date)
+    click.echo(
+        "{} package index{} to be rebuilt starting from {}".format(
+            total, "" if total < 2 else "es", start_date
+        )
     )
 
-    context = {'model': model, 'ignore_auth': True, 'validate': False,
-               'use_cache': False}
+    context = {
+        "model": model,
+        "ignore_auth": True,
+        "validate": False,
+        "use_cache": False,
+    }
     package_index = index_for(model.Package)
     quiet = False
     force = True
     defer_commit = True
     for counter, pkg_id in enumerate(package_ids):
         if not quiet:
-            click.echo(u'Indexing dataset {}/{}: {}'.format(
-                counter + 1, total, pkg_id)
-            )
+            click.echo("Indexing dataset {}/{}: {}".format(counter + 1, total, pkg_id))
         try:
             package_index.update_dict(
-                logic.get_action('package_show')(
-                    context,
-                    {'id': pkg_id}
-                ),
-                defer_commit
+                logic.get_action("package_show")(context, {"id": pkg_id}), defer_commit
             )
         except Exception as e:
-            log.error(u'Error while indexing dataset %s: %s' %
-                      (pkg_id, repr(e)))
+            log.error("Error while indexing dataset %s: %s" % (pkg_id, repr(e)))
             if force:
                 log.error(text_traceback())
                 continue
@@ -450,8 +450,8 @@ def update_tracking_solr(engine, start_date):
 def text_traceback():
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        res = 'the original traceback:'.join(
-            cgitb.text(sys.exc_info()).split('the original traceback:')[1:]
+        res = "the original traceback:".join(
+            cgitb.text(sys.exc_info()).split("the original traceback:")[1:]
         ).strip()
     return res
 

--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -249,13 +249,14 @@ def _normalize_type(_type):
 
 
 def index_for(_type):
-    """Get a SearchIndex instance sub-class suitable for
-    the specified type."""
+    """
+    Get a SearchIndex instance sub-class suitable for the specified type.
+    """
     try:
         _type_n = _normalize_type(_type)
         return _INDICES[_type_n]()
     except KeyError:
-        log.warn("Unknown search type: %s" % _type)
+        log.warn(f"Unknown search type: {_type}")
         return NoopSearchIndex()
 
 
@@ -264,7 +265,7 @@ def get_all_entity_ids_and_date(max_results: int = 1000):
     Return a list of the IDs and metadata_modified of all indexed packages.
     """
     query = "*:*"
-    fq = '+site_id:"%s" ' % config.get("ckan.site_id")
+    fq = f'+site_id:"{config.get("ckan.site_id")}" '
     fq += "+state:active "
 
     conn = make_connection()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name="ckanext-geodatagov",
-    version="0.1.15",
+    version="0.1.16",
     description="",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
# Pull Request

Related to https://github.com/GSA/data.gov/issues/3648

## About

<!-- any pertinent notes -->

- Hardcoded dataset urls in sitemaps:
    - From `<loc>https://catalog-prod-admin-datagov.app.cloud.gov/dataset/alaska-division-of-geological-and-geophysical-surveys</loc>` 
    - To `<loc>https://catalog.data.gov/dataset/alaska-division-of-geological-and-geophysical-surveys</loc>` 
- Some linting/tidying 

## PR TASKS

- [x] The actual code changes.
- [x] Tests written and passed.
- [ ] ~Any changes to docs?~
- [x] Bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/1b1bad0b2ff06112e18c7f4f4fb1143baec1266a/setup.py#L13) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).
