### PR TITLE
Fix harvest failure

### DIFF
--- a/ckanext/geodatagov/harvesters/arcgis.py
+++ b/ckanext/geodatagov/harvesters/arcgis.py
@@ -123,7 +123,7 @@ class ArcGISHarvester(SpatialHarvester, SingletonPlugin):
     def gather_stage(self, harvest_job):
 
         self.harvest_job = harvest_job
-        source_url = harvest_job.source.url
+        source_url = harvest_job.source.url + '/'
         source_config = json.loads(harvest_job.source.config or '{}')
         extra_search_criteria = source_config.get('extra_search_criteria')
 

--- a/ckanext/geodatagov/harvesters/arcgis.py
+++ b/ckanext/geodatagov/harvesters/arcgis.py
@@ -132,7 +132,7 @@ class ArcGISHarvester(SpatialHarvester, SingletonPlugin):
         modified_from = 0
         modified_to = 999999999999999999
 
-        query_template = 'modified:[{modified_from}+TO+{modified_to}]'
+        query_template = 'modified:%5B{modified_from}%20TO%20{modified_to}%5D'
 
         if extra_search_criteria:
             query_template = query_template + ' AND (%s)' % extra_search_criteria

--- a/ckanext/geodatagov/harvesters/arcgis.py
+++ b/ckanext/geodatagov/harvesters/arcgis.py
@@ -44,7 +44,7 @@ def _slugify(value):
     """
     if not isinstance(value, str):
         value = str(value)
-    value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore')
+    value = unicodedata.normalize('NFKD', value)
     value = str(_slugify_strip_re.sub('', value).strip().lower())
     return _slugify_hyphenate_re.sub('-', value)
 

--- a/ckanext/geodatagov/harvesters/arcgis.py
+++ b/ckanext/geodatagov/harvesters/arcgis.py
@@ -53,6 +53,7 @@ def _slugify(value):
 class MLStripper(HTMLParser):
     def __init__(self):
         self.reset()
+        self.convert_charrefs = True
         self.fed = []
 
     def handle_data(self, d):

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,8 @@ omit=ckanext/geodatagov/tests/*
 
 [flake8]
 max-line-length = 127
-ignore = E402  # TODO disable once future.standard_libary is removed
+# TODO disable once future.standard_libary is removed
+ignore = E402  
 
 [tool:pytest]
 norecursedirs=ckanext/geodatagov/tests/nose

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name="ckanext-geodatagov",
-    version="0.1.16",
+    version="0.1.17",
     description="",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
# Pull Request

Related to 

https://github.com/GSA/data.gov/issues/4065 
https://github.com/GSA/data.gov/issues/4108

## About

Harvest failure from https://gisportal.ibwc.gov/agsportal/

- Added extra '/' for source URL to avoid the path lost.
- Changed the encode for [ ] in the search query.
- Fixed Python3 errors.

## PR TASKS

- [x] The actual code changes.
- [x] Bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/1b1bad0b2ff06112e18c7f4f4fb1143baec1266a/setup.py#L13) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).
