### PR TITLE
Add info to check stuck job

### DIFF
--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -416,12 +416,12 @@ def check_stuck_jobs():
     # get source title and org title
     report_jobs = (
         model.Session.query(
-                            model.Package.id, 
-                            model.Package.title.label("source_name"), 
-                            model.Group.title.label("org_name"), 
-                            HarvestJob.created, 
-                            func.now().label('current'),
-                            func.extract("hour", func.now() - HarvestJob.created).label('hours'))
+            model.Package.id,
+            model.Package.title.label("source_name"),
+            model.Group.title.label("org_name"),
+            HarvestJob.created,
+            func.now().label('current'),
+            func.extract("hour", func.now() - HarvestJob.created).label('hours'))
         .join(model.Group, model.Package.owner_org == model.Group.id)
         .join(HarvestJob, HarvestJob.source_id == model.Package.id)
         .filter(model.Package.id.in_(stuck_jobs))

--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -408,22 +408,37 @@ def check_stuck_jobs():
         model.Session.query(HarvestJob.source_id.label("id"))
         .filter(
             HarvestJob.status == "Running",
-            func.extract("day", func.now() - HarvestJob.created) >= 1,
+            func.extract("hour", func.now() - HarvestJob.created) >= 24,
         )
         .subquery()
     )
 
     # get source title and org title
     report_jobs = (
-        model.Session.query(model.Package.id, model.Package.title, model.Group.title)
+        model.Session.query(
+                            model.Package.id, 
+                            model.Package.title.label("source_name"), 
+                            model.Group.title.label("org_name"), 
+                            HarvestJob.created, 
+                            func.now().label('current'),
+                            func.extract("hour", func.now() - HarvestJob.created).label('hours'))
         .join(model.Group, model.Package.owner_org == model.Group.id)
+        .join(HarvestJob, HarvestJob.source_id == model.Package.id)
         .filter(model.Package.id.in_(stuck_jobs))
         .all()
     )
 
     log.info(f"total {len(report_jobs)} stuck harvest jobs")
+
     for job in report_jobs:
-        log.info(job)
+        message = "\nsource_id: " + job.id + \
+                  "\ncreated_time: " + job.created.strftime("%Y-%m-%d-%H:%M:%S") + \
+                  "\ncurrent_time: " + job.current.strftime("%Y-%m-%d-%H:%M:%S") + \
+                  "\nrunning_hours: " + str(int(job.hours)) + \
+                  "\nsource_title: " + job.source_name + \
+                  "\norganization: " + job.org_name
+
+        log.info(message)
 
     sys.exit(len(report_jobs))
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name="ckanext-geodatagov",
-    version="0.1.21",
+    version="0.1.22",
     description="",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
# Pull Request

Related to [[Add more information for the stuck harvest job report#4184](https://github.com/GSA/data.gov/issues/4184)]

## About

We have a stuck job reported on production, but job shows finished about 11 hours, so we need to add more information in the check-stuck-job command to capture states at the time reporting stuck jobs. 

## PR TASKS

- [x] The actual code changes.
- [x] Bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/main/setup.py#L13) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).
