### PR TITLE
Fix issue for checking stuck jobs with time difference format 

### DIFF
--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -408,7 +408,7 @@ def check_stuck_jobs():
         model.Session.query(HarvestJob.source_id.label("id"))
         .filter(
             HarvestJob.status == "Running",
-            func.extract("epoch", func.now() - HarvestJob.created) / 3600 >= 24,
+            (func.extract("epoch", func.now() - HarvestJob.created) / 3600) >= 24,
         )
         .subquery()
     )

--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -408,7 +408,7 @@ def check_stuck_jobs():
         model.Session.query(HarvestJob.source_id.label("id"))
         .filter(
             HarvestJob.status == "Running",
-            (func.extract("epoch", func.now() - HarvestJob.created) / 3600) >= 24,
+            func.extract("day", func.now() - HarvestJob.created) >= 1,
         )
         .subquery()
     )
@@ -421,7 +421,7 @@ def check_stuck_jobs():
             model.Group.title.label("org_name"),
             HarvestJob.created,
             func.now().label('current'),
-            (func.extract("epoch", func.now() - HarvestJob.created) / 3600).label('hours'))
+            (func.now() - HarvestJob.created).label('time_diff'))
         .join(model.Group, model.Package.owner_org == model.Group.id)
         .join(HarvestJob, HarvestJob.source_id == model.Package.id)
         .filter(model.Package.id.in_(stuck_jobs))
@@ -434,7 +434,7 @@ def check_stuck_jobs():
         message = "\nsource_id: " + job.id + \
                   "\ncreated_time: " + job.created.strftime("%Y-%m-%d-%H:%M:%S") + \
                   "\ncurrent_time: " + job.current.strftime("%Y-%m-%d-%H:%M:%S") + \
-                  "\nrunning_hours: " + str(int(job.hours)) + \
+                  "\nrunning_hours: " + str(job.time_diff) + \
                   "\nsource_title: " + job.source_name + \
                   "\norganization: " + job.org_name
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name="ckanext-geodatagov",
-    version="0.1.23",
+    version="0.1.24",
     description="",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
# Pull Request

Related to [[Add more information for the stuck harvest job report#4184](https://github.com/GSA/data.gov/issues/4184)]

## About

Changed the way to check time difference between now and created time. And output the raw format of the time diff.

## PR TASKS

- [x] The actual code changes.
- [x] Bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/main/setup.py#L13) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).