### PR TITLE
Sync harvest object

### DIFF
--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -297,6 +297,7 @@ def get_all_entity_ids_and_date(max_results: int = 1000):
     query = "*:*"
     fq = '+site_id:"%s" ' % config.get("ckan.site_id")
     fq += "+state:active "
+    fq += "+type:dataset "
 
     conn = make_connection()
     data = conn.search(query, fq=fq, rows=max_results, fl="id, metadata_modified")
@@ -346,7 +347,8 @@ def db_solr_sync(dryrun, cleanup_solr, update_solr):
     active_package = [
         (r[0], r[1].replace(microsecond=0))
         for r in model.Session.query(model.Package.id, model.Package.metadata_modified)
-        .filter(model.Package.state != "deleted")
+        .filter(model.Package.type == "dataset")
+        .filter(model.Package.state == "active")
         .all()
     ]
     log.info(f"total {len(active_package)} DB active_package")

--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -294,7 +294,7 @@ def get_all_entity_ids_date_hoid():
     """
     Return a list of the IDs and metadata_modified of all indexed packages.
 
-    harvest_object_id is not readily available from solr result. It has to 
+    harvest_object_id is not readily available from solr result. It has to
     be extracted from a json object validated_data_dict. Due to the large size
     of validated_data_dict, Solr result has to be processed in batches at 10000
     pagination to avoid out-of-memory.

--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -366,7 +366,7 @@ def db_solr_sync(dryrun, cleanup_solr, update_solr):
             HarvestObject,
             and_(
                 HarvestObject.package_id == model.Package.id,
-                HarvestObject.current == True # noqa: E712
+                HarvestObject.current == True  # noqa: E712
             ),
             isouter=True
         )

--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -293,6 +293,11 @@ def index_for(_type):
 def get_all_entity_ids_date_hoid():
     """
     Return a list of the IDs and metadata_modified of all indexed packages.
+
+    harvest_object_id is not readily available from solr result. It has to 
+    be extracted from a json object validated_data_dict. Due to the large size
+    of validated_data_dict, Solr result has to be processed in batches at 10000
+    pagination to avoid out-of-memory.
     """
     query = "*:*"
     fq = '+site_id:"%s" ' % config.get("ckan.site_id")

--- a/ckanext/geodatagov/tests/test_db_solr_sync.py
+++ b/ckanext/geodatagov/tests/test_db_solr_sync.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 import pytest
@@ -8,6 +9,10 @@ import ckan.lib.search as search
 from ckan.tests import factories
 from ckan.tests.helpers import reset_db
 from click.testing import CliRunner
+
+from ckanext.harvest.model import HarvestObject
+from ckanext.harvest.tests import factories as harvest_factories
+from ckanext.harvest.logic import HarvestJobExists
 
 import ckanext.geodatagov.cli as cli
 
@@ -27,6 +32,15 @@ class TestSolrDBSync(object):
         self.dataset2 = factories.Dataset(owner_org=organization["id"])
         self.dataset3 = factories.Dataset(owner_org=organization["id"])
         self.dataset4 = factories.Dataset(owner_org=organization["id"])
+        # 5 is dedicated for harvest_object_id testing
+        self.dataset5 = factories.Dataset(owner_org=organization["id"])
+        dataset5_hoid = HarvestObject(
+            package_id=self.dataset5['id'],
+            job=create_harvest_job(),
+            current=True
+        )
+        dataset5_hoid.save()
+
         search.rebuild()
 
         # Case 1 - in DB, NOT in Solr
@@ -75,6 +89,26 @@ class TestSolrDBSync(object):
         assert (self.dataset3['id'] in case4_db) and (self.dataset3['id'] in case4_solr)
         assert (self.dataset4['id'] not in case4_db) and (self.dataset4['id'] in case4_solr)
 
+        # Case 5 - changing harvest_object_id in DB makes Solr out of date
+        # Solr starts with the same id as the current harvest_object.id
+        assert get_solr_hoid(self.dataset5['id']) == dataset5_hoid.id
+
+        # mark the current harvest_object outdated
+        dataset5_hoid.current = False
+        dataset5_hoid.save()
+
+        # a new harvest_object with a new id.
+        new_dataset5_hoid = HarvestObject(
+            id='newid',
+            package_id=dataset5_hoid.package_id,
+            job=dataset5_hoid.job,
+            current=True
+        )
+        new_dataset5_hoid.save()
+
+        # Solr is unaware of the new id
+        assert get_solr_hoid(self.dataset5['id']) != 'newid'
+
     @pytest.fixture
     def cli_result(self):
         self.create_datasets()
@@ -100,6 +134,8 @@ class TestSolrDBSync(object):
         assert self.dataset3['id'] in final_db and self.dataset3['id'] in final_solr
         assert get_db_id_time(self.dataset3["id"]) == get_solr_id_time(self.dataset3["id"])
         assert self.dataset4['id'] not in final_db and self.dataset4['id'] not in final_solr
+
+        assert get_solr_hoid(self.dataset5['id']) == "newid"
 
 
 def get_active_db_ids():
@@ -146,3 +182,45 @@ def get_solr_id_time(id):
     data = conn.search(query, fq=fq, rows=10, fl='metadata_modified')
 
     return [r.get('metadata_modified') for r in data.docs]
+
+
+def get_solr_hoid(id):
+    """
+    Return the harvest_object_id for a particular package id in Solr.
+    """
+    query = "*:*"
+    fq = "+site_id:\"%s\" " % config.get('ckan.site_id')
+    fq += "+state:active "
+    fq += "+id:%s" % (id)
+
+    conn = make_connection()
+    data = conn.search(query, fq=fq, rows=10, fl='validated_data_dict')
+
+    harvest_object_id = None
+    if data.docs:
+        data_dict = json.loads(data.docs[0].get("validated_data_dict"))
+        for extra in data_dict.get("extras", []):
+            if extra["key"] == "harvest_object_id":
+                harvest_object_id = extra["value"]
+                break
+
+    return harvest_object_id
+
+def create_harvest_job():
+
+    SOURCE_DICT = {
+        "url": "http://test",
+        "name": "test-ho-id",
+        "title": "Test source harvest object id",
+        "source_type": "ckan",
+        "frequency": "MANUAL"
+    }
+    source = harvest_factories.HarvestSourceObj(**SOURCE_DICT)
+    try:
+        job = harvest_factories.HarvestJobObj(source=source)
+    except HarvestJobExists:  # not sure why
+        job = source.get_jobs()[0]
+
+    job.save()
+
+    return job

--- a/ckanext/geodatagov/tests/test_db_solr_sync.py
+++ b/ckanext/geodatagov/tests/test_db_solr_sync.py
@@ -206,8 +206,11 @@ def get_solr_hoid(id):
 
     return harvest_object_id
 
-def create_harvest_job():
 
+def create_harvest_job():
+    """
+    Create a fictitious harvest job object and return it
+    """
     SOURCE_DICT = {
         "url": "http://test",
         "name": "test-ho-id",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name="ckanext-geodatagov",
-    version="0.1.25",
+    version="0.1.26",
     description="",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
# Pull Request

Related to https://github.com/GSA/data.gov/issues/4177

## About

This add `harvest_object_id` into db-solr-sync, so that we are comparing tuple `(package_id, last_modified_date, harvest_object_id)` between dn and solr to determine if a package need a re-index. 

## PR TASKS

- [x] The actual code changes.
- [x] Tests written and passed.
- [x] ~Any changes to docs?~
- [x] Bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/main/setup.py#L13) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).
