### PR TITLE
Fix leading zero regex

### DIFF
--- a/ckanext/geodatagov/logic.py
+++ b/ckanext/geodatagov/logic.py
@@ -466,7 +466,7 @@ def translate_spatial(old_spatial):
     # all leading 0s, '[-089.63,  30.36]' is not valid, '[-89.63,  30.36]' is valid
     old_spatial_transformed = old_spatial.replace('+', '')
     old_spatial_transformed = old_spatial_transformed.replace('.,', ',').replace('.]', ']')
-    old_spatial_transformed = re.sub(r'(?<!\.)(-?)0+([1-9][0-9]+(\.[0-9]*)?)', r'\1\2', old_spatial_transformed)
+    old_spatial_transformed = re.sub(r'(\s)(-?)0+((0|[1-9][0-9]*)(\.[0-9]*)?)', r'\1\3', old_spatial_transformed)
 
     # Analyze with type of data is JSON valid
     try:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name="ckanext-geodatagov",
-    version="0.1.30",
+    version="0.1.31",
     description="",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Related to
- #251 
- https://github.com/GSA/catalog.data.gov/pull/890#pullrequestreview-1355455689

Changes:
- New Leading Zero Regex: `(\s)(-?)0+((0|[1-9][0-9]*)(\.[0-9]*)?)`
- Test Conditions
  ```bash
  14.601813, 080, 080.012, 83.0312, 090.01, 
  14.01813, 0.001, -1.2, -010.02, -010.02000,
  14.332601813, 080, 00334, 01, 02, 03
  0.0123, 0.123, 000123
  0.001, 0.01, 02, 
  ```

![image](https://user-images.githubusercontent.com/85196563/227563463-91516954-fb9b-4f33-a2b7-ae233de0bbe5.png)
