### PR TITLE
speed up relink by improving solr indexing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name="ckanext-geodatagov",
-    version="0.1.35",
+    version="0.1.36",
     description="",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Looks like we need to turn manual relink process into a nightly job since we see a few thousand packages that need to be relinked in every a few days. This commit change solr indexing from package by package to batch processing, so it speeds up the process to make it ready to turn into a GH cron action.