### PR TITLE
skip datasets without harvest object from db-solr-sync

### DIFF
--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -398,11 +398,18 @@ def db_solr_sync(dryrun, cleanup_solr, update_solr):
 
     # in case an id comes with multiple harvest_object_id,
     # this removes anything but the latest
+    # after which we have a dict formatted as
+    # {
+    #   'some_id': (some_mod_date, some_ho_id)
+    #   ...
+    # }
     cleaning = {}
     for id, metadata_modified, harvest_object_id in active_package:
         cleaning[id] = (metadata_modified, harvest_object_id)
 
     # now it is cleaned, change dict back to a set.
+    # after which we are back to a set formatted as
+    # {(some_id, some_mod_date, some_ho_id), ...}
     active_package = {(k,) + cleaning[k] for k in cleaning}
     # pick out those packages without harvest_object_id
     active_package_id_wo_ho = {k for k in cleaning if cleaning[k][1] is None}

--- a/ckanext/geodatagov/tests/test_db_solr_sync.py
+++ b/ckanext/geodatagov/tests/test_db_solr_sync.py
@@ -38,6 +38,8 @@ class TestSolrDBSync(object):
         add_harvest_object(self.dataset4)
         self.dataset5 = factories.Dataset(owner_org=organization["id"])
         ho5 = add_harvest_object(self.dataset5)
+        # dataset6 has no harvest object.
+        self.dataset6 = factories.Dataset(owner_org=organization["id"])
 
         search.rebuild()
 
@@ -101,6 +103,10 @@ class TestSolrDBSync(object):
         # Solr is unaware of the new id
         assert get_solr_hoid(self.dataset5['id']) != 'newid'
 
+        # Case 6 - Remove dataset from SOLR
+        # different from case 1, dataset6 should be added back to index after script run
+        package_index.remove_dict({'id': self.dataset6["id"]})
+
     @pytest.fixture
     def cli_result(self):
         self.create_datasets()
@@ -128,6 +134,8 @@ class TestSolrDBSync(object):
         assert self.dataset4['id'] not in final_db and self.dataset4['id'] not in final_solr
 
         assert get_solr_hoid(self.dataset5['id']) == "newid"
+
+        assert self.dataset6['id'] in final_db and self.dataset6['id'] not in final_solr
 
 
 def get_active_db_ids():

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name="ckanext-geodatagov",
-    version="0.1.36",
+    version="0.1.37",
     description="",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
# Pull Request

Related to https://github.com/GSA/data.gov/issues/4355

## About

db-solr-sync script does not know how to handle datasets without harvest objects. We should exclude them from the update list to save the resource

## PR TASKS

- [x] The actual code changes.
- [x] Tests written and passed.
- [x] Any changes to docs?
- [x] Bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/main/setup.py#L13) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).
