### PR TITLE
Spatial empty string

### DIFF
--- a/ckanext/geodatagov/logic.py
+++ b/ckanext/geodatagov/logic.py
@@ -472,7 +472,7 @@ def translate_spatial(old_spatial):
     # all trailing decimals, '[34., 2]' is not valid, but '[34.0, 2]' and '[34, 2]' are valid
     old_spatial_transformed = old_spatial_transformed.replace('.,', ',').replace('.]', ']')
     # '-98, 29, -83, 35.' is not valid
-    if old_spatial_transformed[-1] == '.':
+    if old_spatial_transformed != "" and old_spatial_transformed[-1] == '.':
         old_spatial_transformed = old_spatial_transformed[0:-1]
     # all leading 0s, '[-089.63,  30.36]' is not valid, '[-89.63,  30.36]' is valid
     old_spatial_transformed = re.sub(r'(^|\s)(-?)0+((0|[1-9][0-9]*)(\.[0-9]*)?)', r'\1\2\3', old_spatial_transformed)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name="ckanext-geodatagov",
-    version="0.2.1",
+    version="0.2.2",
     description="",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
# Pull Request

old_spatial_transformed could be ""

## About

Error on prod fetch complaining IndexError on line 
`if old_spatial_transformed[-1] == '.':`

## PR TASKS

- [x] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [x] Bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/main/setup.py#L13) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).
