### PR TITLE
uses 'fl' instead of 'fields' to only return the fields we care about

### DIFF
--- a/ckanext/geodatagov/search.py
+++ b/ckanext/geodatagov/search.py
@@ -42,7 +42,7 @@ class GeoPackageSearchQuery(PackageSearchQuery):
             data = conn.search(query,
                                fq=fq,
                                rows=max_results,
-                               fields='name,metadata_modified',
+                               fl='name,metadata_modified',
                                start=start,
                                sort='metadata_created asc')
         except Exception as e:

--- a/setup.py
+++ b/setup.py
@@ -5,34 +5,34 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the relevant file
-with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+with open(path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
     name="ckanext-geodatagov",
-    version="0.2.2",
+    version="0.2.3",
     description="",
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     classifiers=[
-        'Programming Language :: Python :: 3'
+        "Programming Language :: Python :: 3"
     ],  # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
-    keywords='',
-    author='Data.gov',
-    author_email='datagovhelp@gsa.gov',
-    url='https://github.com/GSA/ckanext-geodatagov',
-    license='',
-    packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
-    namespace_packages=['ckanext', 'ckanext.geodatagov'],
+    keywords="",
+    author="Data.gov",
+    author_email="datagovhelp@gsa.gov",
+    url="https://github.com/GSA/ckanext-geodatagov",
+    license="",
+    packages=find_packages(exclude=["ez_setup", "examples", "tests"]),
+    namespace_packages=["ckanext", "ckanext.geodatagov"],
     include_package_data=True,
     zip_safe=False,
     install_requires=[
         # -*- Extra requirements: -*-
-        'ckanext-datajson>=0.1.19',
-        'boto3',
-        'ply>=3.4',
+        "ckanext-datajson>=0.1.19",
+        "boto3",
+        "ply>=3.4",
     ],
-    setup_requires=['wheel'],
+    setup_requires=["wheel"],
     entry_points="""
         [ckan.plugins]
     # Add plugins here, eg


### PR DESCRIPTION
# Pull Request

Related to https://github.com/GSA/catalog.data.gov/issues/990

## About

<!-- any pertinent notes -->

## PR TASKS

- [X] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [x] Bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/main/setup.py#L13) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).
