### PR TITLE
bumps pypi version to 0.2.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="ckanext-geodatagov",
-    version="0.2.3",
+    version="0.2.4",
     description="",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# Pull Request

Related to https://github.com/GSA/ckanext-geodatagov/pull/265

## About

<!-- any pertinent notes -->

## PR TASKS

- [ ] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/main/setup.py#L13) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).
