### PR TITLE
S3 delete objects

### DIFF
--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -206,12 +206,12 @@ def upload_to_key(upload_str: str, filename_on_s3: str) -> None:
 
 
 def delete_old_sitemaps():
-    objects_to_delete = S3.meta.client.list_objects(Bucket=BUCKET_NAME, Prefix=PREFIX)
+    objects_to_delete = S3.list_objects(Bucket=BUCKET_NAME, Prefix=PREFIX)
 
     delete_keys = {'Objects': []}
     delete_keys['Objects'] = [{'Key': k} for k in [obj['Key'] for obj in objects_to_delete.get('Contents', [])]]
 
-    S3.meta.client.delete_objects(Bucket=BUCKET_NAME, Delete=delete_keys)
+    S3.delete_objects(Bucket=BUCKET_NAME, Delete=delete_keys)
 
 
 def upload_sitemap_file(sitemap: list) -> None:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="ckanext-geodatagov",
-    version="0.2.5",
+    version="0.2.6",
     description="",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# Pull Request

Related to https://github.com/GSA/catalog.data.gov/issues/1075

## About

`S3` is from `S3 = boto3.client()`, not `S3 = boto3.resource()`. A better name would be `s3_client`.

<!-- any pertinent notes -->

## PR TASKS

- [x] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [x] Bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/main/setup.py#L13) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).
