### PR TITLE
use s3 delete-object to avoid Content-MD5 error

### DIFF
--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -206,12 +206,11 @@ def upload_to_key(upload_str: str, filename_on_s3: str) -> None:
 
 
 def delete_old_sitemaps():
-    objects_to_delete = S3.list_objects(Bucket=BUCKET_NAME, Prefix=PREFIX)
+    objects_to_delete = S3.list_objects_v2(Bucket=BUCKET_NAME, Prefix=PREFIX)
 
-    delete_keys = {'Objects': []}
-    delete_keys['Objects'] = [{'Key': k} for k in [obj['Key'] for obj in objects_to_delete.get('Contents', [])]]
-
-    S3.delete_objects(Bucket=BUCKET_NAME, Delete=delete_keys)
+    for object in objects_to_delete['Contents']:
+        log.info("Deleting {}.".format(object['Key']))
+        S3.delete_object(Bucket=BUCKET_NAME, Key=object['Key'])
 
 
 def upload_sitemap_file(sitemap: list) -> None:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="ckanext-geodatagov",
-    version="0.2.6",
+    version="0.2.7",
     description="",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# Pull Request

Related to https://github.com/GSA/catalog.data.gov/issues/1075

## About

Use `delete_object` instead of `delete_objects`

## PR TASKS

- [x] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [x] Bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/main/setup.py#L13) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).
