### PR TITLE
Unpin pypi github action to v1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
           python setup.py sdist
           python setup.py bdist_wheel
       - name: pypi-publish
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
           python setup.py sdist
           python setup.py bdist_wheel
       - name: pypi-publish
-        uses: pypa/gh-action-pypi-publish@v1.4.2
+        uses: pypa/gh-action-pypi-publish@v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Update setup.py if manual release
         if: github.event_name == 'workflow_dispatch'
         run: |


### PR DESCRIPTION
# Pull Request

Same as https://github.com/GSA/ckanext-geodatagov/pull/275, https://github.com/GSA/ckanext-datajson/pull/151, https://github.com/GSA/ckanext-dcat_usmetadata/pull/325, https://github.com/GSA/ckanext-datagovtheme/pull/179.

## About

<!-- any pertinent notes -->

The current [action version](https://github.com/pypa/gh-action-pypi-publish) is `v1.8.11`. This PR unpins the action to keep it up to date as `v1` changes take place. 
