### PR TITLE
fix UI issue when a collection dataset with missing parent

### DIFF
--- a/ckanext/geodatagov/helpers.py
+++ b/ckanext/geodatagov/helpers.py
@@ -3,6 +3,7 @@ import logging
 
 from ckan import plugins as p
 from ckanext.harvest.model import HarvestSource
+from ckan.logic import NotFound, NotAuthorized
 
 log = logging.getLogger(__name__)
 
@@ -59,8 +60,11 @@ def get_harvest_source_config(harvester_id):
 
 
 def get_collection_package(collection_package_id):
-    package = p.toolkit.get_action('package_show')({}, {'id': collection_package_id})
-    return package
+    try:
+        package = p.toolkit.get_action('package_show')({}, {'id': collection_package_id})
+        return package
+    except (NotFound, NotAuthorized):
+        pass
 
 
 def string(value):

--- a/ckanext/geodatagov/templates/package/read.html
+++ b/ckanext/geodatagov/templates/package/read.html
@@ -20,7 +20,7 @@
             {% snippet "snippets/package_item.html", package=collection_package, truncate=75 %}
         </ul>
     {% else %}
-        <p>{{ _('This dataset is part of the a deleted collection.') }}</p>
+        <p>{{ _('This dataset is part of a deleted collection.') }}</p>
         <p><a href="{{ h.url_for('search', collection_package_id=collection_package_id) }}" class="btn-collection">{{ _('Search other datasets within the same collection') }}</a></p>
     {% endif %}
 </section>

--- a/ckanext/geodatagov/templates/package/read.html
+++ b/ckanext/geodatagov/templates/package/read.html
@@ -20,7 +20,7 @@
             {% snippet "snippets/package_item.html", package=collection_package, truncate=75 %}
         </ul>
     {% else %}
-        <p>{{ _('This dataset is part of the a collection.') }}</p>
+        <p>{{ _('This dataset is part of the a deleted collection.') }}</p>
         <p><a href="{{ h.url_for('search', collection_package_id=collection_package_id) }}" class="btn-collection">{{ _('Search other datasets within the same collection') }}</a></p>
     {% endif %}
 </section>

--- a/ckanext/geodatagov/templates/package/read.html
+++ b/ckanext/geodatagov/templates/package/read.html
@@ -14,10 +14,15 @@
 {% set collection_package = h.get_collection_package(collection_package_id) %}
 <section class="module-content">
     <h3>{{ _('Collection') }}</h3>
-    <p>{{ _('This dataset is part of the following collection:') }}</p>
-    <ul class="dataset-list unstyled">
-        {% snippet "snippets/package_item.html", package=collection_package, truncate=75 %}
-    </ul>
+    {% if collection_package %}
+        <p>{{ _('This dataset is part of the following collection:') }}</p>
+        <ul class="dataset-list unstyled">
+            {% snippet "snippets/package_item.html", package=collection_package, truncate=75 %}
+        </ul>
+    {% else %}
+        <p>{{ _('This dataset is part of the a collection.') }}</p>
+        <p><a href="{{ h.url_for('search', collection_package_id=collection_package_id) }}" class="btn-collection">{{ _('Search other datasets within the same collection') }}</a></p>
+    {% endif %}
 </section>
 {% endif %}
 {% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="ckanext-geodatagov",
-    version="0.2.7",
+    version="0.2.8",
     description="",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# Pull Request

Related to https://github.com/GSA/data.gov/issues/4553

## About

- added exception for parent dataset absent in collection
- changed the UI to display differently to still allow user to search other datasets within same collection.


## PR TASKS

- [x] The actual code changes.
- [x] Bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/main/setup.py#L13) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).
