### PR TITLE
Add db-solr-sync-next for catalog-next

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV CLASSPATH=${CLASSPATH}:/usr/lib/jvm/java-11-openjdk/saxon/saxon.jar
 RUN pip install --upgrade pip
 # RUN python3 -m pip install 'cython<3'
 # RUN python3 -m pip install --no-use-pep517 pyproj==3.4.1
-RUN python3 -m pip install pyproj@git+https://github.com/pyproj4/pyproj.git@main
+RUN python3 -m pip install pyproj@git+https://github.com/pyproj4/pyproj.git@3.6.1
 
 COPY . $APP_DIR/
 

--- a/Makefile
+++ b/Makefile
@@ -2,28 +2,28 @@ CKAN_VERSION ?= 2.10
 COMPOSE_FILE ?= docker-compose.yml
 
 build: ## Build the docker containers
-	CKAN_VERSION=$(CKAN_VERSION) docker-compose -f $(COMPOSE_FILE) build
+	CKAN_VERSION=$(CKAN_VERSION) docker compose -f $(COMPOSE_FILE) build
 debug:
-	CKAN_VERSION=$(CKAN_VERSION) docker-compose run --service-ports app
+	CKAN_VERSION=$(CKAN_VERSION) docker compose run --service-ports app
 
 lint: ## Lint the code
-	CKAN_VERSION=$(CKAN_VERSION) docker-compose -f docker-compose.yml run --rm app flake8 /srv/app/ckanext/ --count --max-line-length=127 --show-source --statistics --exclude ckan
+	CKAN_VERSION=$(CKAN_VERSION) docker compose -f docker-compose.yml run --rm app flake8 /srv/app/ckanext/ --count --max-line-length=127 --show-source --statistics --exclude ckan
 
 clean: ## Clean workspace and containers
 	find . -name *.pyc -delete
-	CKAN_VERSION=$(CKAN_VERSION) docker-compose -f $(COMPOSE_FILE) down -v --remove-orphans
+	CKAN_VERSION=$(CKAN_VERSION) docker compose -f $(COMPOSE_FILE) down -v --remove-orphans
 
 test: ## Run tests in a new container
-	CKAN_VERSION=$(CKAN_VERSION) docker-compose -f $(COMPOSE_FILE) run --rm app /srv/app/test.sh
+	CKAN_VERSION=$(CKAN_VERSION) docker compose -f $(COMPOSE_FILE) run --rm app /srv/app/test.sh
 
 java-test: ## Test java transformation command (java + saxon installed)
-	CKAN_VERSION=$(CKAN_VERSION) docker-compose -f $(COMPOSE_FILE) run --rm app bash -c "java net.sf.saxon.Transform -s:/app/ckanext/geodatagov/tests/data-samples/waf-fgdc/fgdc-csdgm_sample.xml -xsl:/app/ckanext/geodatagov/harvesters/fgdcrse2iso19115-2.xslt"
+	CKAN_VERSION=$(CKAN_VERSION) docker compose -f $(COMPOSE_FILE) run --rm app bash -c "java net.sf.saxon.Transform -s:/app/ckanext/geodatagov/tests/data-samples/waf-fgdc/fgdc-csdgm_sample.xml -xsl:/app/ckanext/geodatagov/harvesters/fgdcrse2iso19115-2.xslt"
 
 up: ## Start the containers
-	CKAN_VERSION=$(CKAN_VERSION) docker-compose -f $(COMPOSE_FILE) up
+	CKAN_VERSION=$(CKAN_VERSION) docker compose -f $(COMPOSE_FILE) up
 
 ci: ## Start the containers in the background
-	CKAN_VERSION=$(CKAN_VERSION) docker-compose -f $(COMPOSE_FILE) up -d
+	CKAN_VERSION=$(CKAN_VERSION) docker compose -f $(COMPOSE_FILE) up -d
 
 .DEFAULT_GOAL := help
 .PHONY: build clean help lint test up

--- a/README.md
+++ b/README.md
@@ -46,18 +46,18 @@ All the tests live in the [/ckanext/geodatagov/tests](/ckanext/geodatagov/tests)
 ### Build Environment
 
 To start environment, run:
-```docker-compose build```
-```docker-compose up```
+```docker compose build```
+```docker compose up```
 
 CKAN will start at localhost:5000
 
 To shut down environment, run:
 
-```docker-compose down```
+```docker compose down```
 
 To docker exec into the CKAN image, run:
 
-```docker-compose exec app /bin/bash```
+```docker compose exec app /bin/bash```
 
 ### Testing
 

--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -478,10 +478,7 @@ def db_solr_sync(dryrun, cleanup_solr, update_solr):
     for id, *_ in solr_package:
         work_list[id] = "solr"
     for id, *_ in db_package:
-        if id in work_list:
-            work_list[id] = "solr-db"
-        else:
-            work_list[id] = "db"
+        work_list[id] = "db"
 
     both = cleanup_solr == update_solr
     set_cleanup = {i if work_list[i] == "solr" else None for i in work_list} - {None}
@@ -565,10 +562,7 @@ def db_solr_sync_next(dryrun, cleanup_solr, update_solr):
     for id, *_ in solr_package:
         work_list[id] = "solr"
     for id, *_ in db_package:
-        if id in work_list:
-            work_list[id] = "solr-db"
-        else:
-            work_list[id] = "db"
+        work_list[id] = "db"
 
     both = cleanup_solr == update_solr
     set_cleanup = {i if work_list[i] == "solr" else None for i in work_list} - {None}

--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -532,7 +532,7 @@ def db_solr_sync(dryrun, cleanup_solr, update_solr):
     ),
 )
 def db_solr_sync_next(dryrun, cleanup_solr, update_solr):
-    """db solr sync next"""
+    """db solr sync next for catalog-next"""
     if dryrun:
         log.info("Starting dryrun to update index.")
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="ckanext-geodatagov",
-    version="0.2.8",
+    version="0.2.9",
     description="",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/test.sh
+++ b/test.sh
@@ -2,7 +2,7 @@
 # Setup and run extension tests. This script should be run in a _clean_ CKAN
 # environment. e.g.:
 #
-#     $ docker-compose run --rm app ./test.sh
+#     $ docker compose run --rm app ./test.sh
 #
 
 set -o errexit


### PR DESCRIPTION
# Pull Request

catalog-next has no harvest objects. `db-solr-sync-next` is am simplified version of `db-solr-sync`. 

## About

<!-- any pertinent notes -->

## PR TASKS

- [x] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/main/setup.py#L13) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).
