### PR TITLE
update ckan docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG CKAN_VERSION=2.10
-FROM openknowledge/ckan-dev:${CKAN_VERSION}
+FROM ckan/ckan-dev:${CKAN_VERSION}
 ARG CKAN_VERSION
 
 RUN apk add geos-dev proj proj-util proj-dev openjdk11-jre


### PR DESCRIPTION
This minor commit changes ckan base image from outdated `openknowledge` to `ckan`, it will also bump ckan core from 2.10.1 to 2.10.7.