### PR TITLE
4624 attr error fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ java-test: ## Test java transformation command (java + saxon installed)
 up: ## Start the containers
 	CKAN_VERSION=$(CKAN_VERSION) docker compose -f $(COMPOSE_FILE) up
 
+down: ## Stop the containers
+	CKAN_VERSION=$(CKAN_VERSION) docker compose -f $(COMPOSE_FILE) down
+
 ci: ## Start the containers in the background
 	CKAN_VERSION=$(CKAN_VERSION) docker compose -f $(COMPOSE_FILE) up -d
 

--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -16,7 +16,7 @@ import click
 import ckan.logic as logic
 import ckan.model as model
 from ckan.common import config
-from ckan.lib.search import rebuild
+from .rebuild import rebuild
 from ckan.lib.search.common import make_connection
 from ckan.lib.search.index import NoopSearchIndex, PackageSearchIndex
 from ckan.model.meta import Session as session

--- a/ckanext/geodatagov/logic.py
+++ b/ckanext/geodatagov/logic.py
@@ -465,7 +465,6 @@ def translate_spatial(old_spatial):
     geojson_tpl = ('{{"type": "Polygon", '
                    '"coordinates": [[[{minx}, {miny}], [{minx}, {maxy}], '
                    '[{maxx}, {maxy}], [{maxx}, {miny}], [{minx}, {miny}]]]}}')
-
     # Replace all things that create bad JSON, https://github.com/GSA/data.gov/issues/3549
     # all instances of '+', '[+23, -1]' is not valid, but '[23, -1]' is valid
     old_spatial_transformed = old_spatial.replace('+', '')
@@ -512,7 +511,7 @@ def translate_spatial(old_spatial):
     except AttributeError:
         pass
 
-    return ''
+    return ""
 
 
 def is_number(s):

--- a/ckanext/geodatagov/rebuild.py
+++ b/ckanext/geodatagov/rebuild.py
@@ -1,0 +1,114 @@
+import logging
+import sys
+
+from typing import Collection, Optional
+
+
+import ckan.model as model
+import ckan.logic as logic
+from ckan.types import Context
+
+from ckan.lib.search.common import (
+    config,
+)
+from ckan.lib.search import index_for, query_for, text_traceback
+
+log = logging.getLogger(__name__)
+
+
+def rebuild(package_id: Optional[str] = None,
+            only_missing: bool = False,
+            force: bool = False,
+            defer_commit: bool = False,
+            package_ids: Optional[Collection[str]] = None,
+            quiet: bool = False,
+            clear: bool = False):
+    '''
+        Rebuilds the search index.
+
+        If a dataset id is provided, only this dataset will be reindexed.
+        When reindexing all datasets, if only_missing is True, only the
+        datasets not already indexed will be processed. If force equals
+        True, if an exception is found, the exception will be logged, but
+        the process will carry on.
+    '''
+    log.info("Rebuilding search index...")
+
+    package_index = index_for(model.Package)
+    context: Context = {
+        'ignore_auth': True,
+        'validate': False,
+        'use_cache': False
+    }
+    if package_id:
+        pkg_dict = logic.get_action('package_show')(context, {
+            'id': package_id
+        })
+        log.info('Indexing just package %r...', pkg_dict['name'])
+        package_index.remove_dict(pkg_dict)
+        package_index.insert_dict(pkg_dict)
+    elif package_ids is not None:
+        for package_id in package_ids:
+            pkg_dict = logic.get_action(
+                'package_show'
+            )
+            (
+                context,
+                {'id': package_id}
+            )
+            log.info("pkg ID %s", package_id)
+            log.info("Indexing just package %r...", pkg_dict["name"])
+            try:
+                package_index.update_dict(pkg_dict, True)
+            except Exception as e:
+                log.error("Error while indexing dataset %s: %s" % (package_id, repr(e)))
+                continue
+    else:
+        packages = model.Session.query(model.Package.id)
+        if config.get('ckan.search.remove_deleted_packages'):
+            packages = packages.filter(model.Package.state != 'deleted')
+
+        package_ids = [r[0] for r in packages.all()]
+
+        if only_missing:
+            log.info('Indexing only missing packages...')
+            package_query = query_for(model.Package)
+            indexed_pkg_ids = set(package_query.get_all_entity_ids(
+                max_results=len(package_ids)))
+            # Packages not indexed
+            package_ids = set(package_ids) - indexed_pkg_ids
+
+            if len(package_ids) == 0:
+                log.info('All datasets are already indexed')
+                return
+        else:
+            log.info('Rebuilding the whole index...')
+            # When refreshing, the index is not previously cleared
+            if clear:
+                package_index.clear()
+
+        total_packages = len(package_ids)
+        for counter, pkg_id in enumerate(package_ids):
+            if not quiet:
+                sys.stdout.write(
+                    "\rIndexing dataset {0}/{1}".format(
+                        counter + 1, total_packages)
+                )
+                sys.stdout.flush()
+            try:
+                package_index.update_dict(
+                    logic.get_action('package_show')(
+                        context,
+                        {'id': pkg_id}
+                    ),
+                    defer_commit
+                )
+            except Exception as e:
+                log.error(u'Error while indexing dataset %s: %s' %
+                          (pkg_id, repr(e)))
+                if force:
+                    log.error(text_traceback())
+                    continue
+
+    model.Session.commit()
+    log.info('Finished rebuilding search index.')

--- a/ckanext/geodatagov/tests/data-samples/sample6_bad_data.json
+++ b/ckanext/geodatagov/tests/data-samples/sample6_bad_data.json
@@ -1,0 +1,92 @@
+{
+	"@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+	"@type": "dcat:Catalog",
+	"conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
+	"describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
+	"dataset": [
+		{
+			"@type": "dcat:Dataset",
+			"accessLevel": "public",
+			"accrualPeriodicity": "R/P1D",
+			"bureauCode": [
+				"581:00"
+			],
+			"contactPoint": {
+				"@type": "vcard:Contact",
+				"fn": "devops@cfpb.gov",
+				"hasEmail": "mailto:devops@cfpb.gov"
+			},
+			"describedBy": "https://cfpb.github.io/api/ccdb/api.html",
+			"description": "The Consumer Complaint Database is a collection of complaints about consumer financial products and services that we sent to companies for response. Complaints are published after the company responds, confirming a commercial relationship with the consumer, or after 15 days, whichever comes first. Complaints referred to other regulators, such as complaints about depository institutions with less than $10 billion in assets, are not published in the Consumer Complaint Database. The database generally updates daily.",
+			"distribution": [
+				{
+					"@type": "dcat:Distribution",
+					"downloadURL": "https://files.consumerfinance.gov/ccdb/complaints.csv.zip",
+					"mediaType": "text/csv"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"downloadURL": "https://files.consumerfinance.gov/ccdb/complaints.json.zip",
+					"mediaType": "application/json"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"format": "API",
+					"accessURL": "https://www.consumerfinance.gov/data-research/consumer-complaints/search/api/v1/"
+				}
+			],
+			"identifier": "CCDB",
+			"keyword": [
+				"consumer",
+				"finance",
+				"complaint",
+				"bank account",
+				"bank service",
+				"credit card",
+				"credit report",
+				"debt collection",
+				"money transfer",
+				"mortgage",
+				"student loan",
+				"loan"
+			],
+			"landingPage": "https://www.consumerfinance.gov/data-research/consumer-complaints/",
+			"modified": "2020-01-13",
+			"programCode": [
+				"000:000"
+			],
+			"publisher": {
+				"@type": "org:Organization",
+				"name": "Consumer Financial Protection Bureau"
+			},
+			"spatial": {
+				"type": "Polygon",
+				"coordinates": [
+					[
+						[
+							-124.733253,
+							24.544245
+						],
+						[
+							-124.733253,
+							49.388611
+						],
+						[
+							-66.954811,
+							49.388611
+						],
+						[
+							-66.954811,
+							24.544245
+						]
+						[
+							-124.733253,
+							24.544245
+						]
+					]
+				]
+			},
+			"title": "Consumer Complaint Database"
+		}
+	]
+}

--- a/ckanext/geodatagov/tests/test_datajson.py
+++ b/ckanext/geodatagov/tests/test_datajson.py
@@ -106,3 +106,16 @@ class TestDataJsonHarvester(object):
                                                 '[-124.733253,24.544245]]]}')
             assert extras['old-spatial'] == 'United States'
             assert extras['programCode'] == ['000:000']
+
+    def test_bad_data_JSONDecodeError(self):
+        """
+        Test for JSONDecodeError when the data.json file is not valid JSON.
+        """
+        self.organization = Organization()
+
+        # testing with data from https://www.consumerfinance.gov/data.json
+        url = f"http://127.0.0.1:{PORT}/sample6_bad_data.json"
+        with pytest.raises(Exception) as error:
+            self.run_gather(url=url)
+
+        assert "JSONDecodeError" in error.value.args[0].message

--- a/ckanext/geodatagov/tests/test_db_solr_sync.py
+++ b/ckanext/geodatagov/tests/test_db_solr_sync.py
@@ -6,7 +6,7 @@ from click.testing import CliRunner
 from ckan.common import config
 from ckan.lib.search.common import make_connection
 import ckan.model as model
-import ckan.lib.search as search
+from ckanext.geodatagov.rebuild import rebuild
 from ckan.tests import factories
 from ckanext.harvest.model import HarvestObject
 from ckanext.harvest.tests import factories as harvest_factories
@@ -37,7 +37,7 @@ class TestSolrDBSync(object):
         # dataset6 has no harvest object.
         self.dataset6 = factories.Dataset(owner_org=organization["id"])
 
-        search.rebuild()
+        rebuild()
 
         # Case 1 - in DB, NOT in Solr
         # -- Everything is okay

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
----
-version: "3.7"
 services:
   app:
     image: datagov/ckanext-geodatagov:${CKAN_VERSION} # ensures docker-compose will rebuild the right image in case we change CKAN_VERSION


### PR DESCRIPTION
# Pull Request

Related to GSA/data.gov#4624

## About
An analysis of the issue:
The old and current `rebuild` calls out to our `package_create` which then calls out to a several other functions such as `rollup_save_action` then to our `translate_spatial`. Within the translate spatial we then call the `json.dump` which we do wrap in an try/except, however this caused the `rebuild` to fail in the update which then led to the rebuild raising the exception and then holding up the index. Switching out the `raise` from the original CKAN code we will instead log the package_ids of failing datasets while not holding up the entire `rebuild`.

I also added a test case in which we take a bad json file that I think helps test bad json that indirectly helps support this change while not directly connected with the rebuild, it does help test for JSON failing json which could trigger the issue with old harvester.

- Adds make command `down` to spin down containers.
- Adds minor lint change
- Cleans up docker compose file to get rid of `version` warning

## PR TASKS

- [ ] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/main/setup.py#L13) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).
