### PR TITLE
add `force` flag in order to make use of non-blocking updates

### DIFF
--- a/ckanext/geodatagov/cli.py
+++ b/ckanext/geodatagov/cli.py
@@ -418,7 +418,12 @@ def delete_packages(package_ids):
         "(Update solr entries with new data from DB) OR (Add DB data to Solr that is missing)"
     ),
 )
-def db_solr_sync(dryrun, cleanup_solr, update_solr):
+@click.option(
+    "--force_rebuild",
+    is_flag=False,
+    help=("Force the rebuild step."),
+)
+def db_solr_sync(dryrun, cleanup_solr, update_solr, force_rebuild):
     """db solr sync"""
     if dryrun:
         log.info("Starting dryrun to update index.")
@@ -498,7 +503,7 @@ def db_solr_sync(dryrun, cleanup_solr, update_solr):
     if not dryrun and set_update and (update_solr or both):
         log.info("Rebuilding indexes")
         try:
-            rebuild(package_ids=set_update, defer_commit=True)
+            rebuild(package_ids=set_update, defer_commit=True, force=force_rebuild)
         except Exception as e:
             log.error("Error while rebuild index %s: %s" % (id, repr(e)))
         package_index.commit()
@@ -530,7 +535,14 @@ def db_solr_sync(dryrun, cleanup_solr, update_solr):
         "(Update solr entries with new data from DB) OR (Add DB data to Solr that is missing)"
     ),
 )
-def db_solr_sync_next(dryrun, cleanup_solr, update_solr):
+@click.option(
+    "--force_rebuild",
+    is_flag=False,
+    help=(
+        "Force the rebuild step."
+    ),
+)
+def db_solr_sync_next(dryrun, cleanup_solr, update_solr, force_rebuild):
     """db solr sync next for catalog-next"""
     if dryrun:
         log.info("Starting dryrun to update index.")
@@ -581,7 +593,7 @@ def db_solr_sync_next(dryrun, cleanup_solr, update_solr):
     if not dryrun and set_update and (update_solr or both):
         log.info("Rebuilding indexes")
         try:
-            rebuild(package_ids=set_update, defer_commit=True)
+            rebuild(package_ids=set_update, defer_commit=True, force=force_rebuild)
         except Exception as e:
             log.error("Error while rebuild index %s: %s" % (id, repr(e)))
         package_index.commit()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="ckanext-geodatagov",
-    version="0.3.4",
+    version="0.3.5",
     description="",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# Pull Request

Related to GSA/data.gov#5268

## About

- adds `force_rebuild` flag
    - In the try/except for `rebuild` we look for a `force` (`bool`) in order to have it so the `raise` is not triggered causing `rebuild` to return with an error. By having `--force_rebuild True` this will tell[ `rebuild` to instead `continue` in the looping of creating the updates](https://github.com/GSA/ckanext-geodatagov/blob/139e6c63d24131817ac4379026bd80e8b5953a49/ckanext/geodatagov/rebuild.py#L49).

## PR TASKS

- [ ] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/main/setup.py#L13) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).
