### PR TITLE
Change default search secondary sort to be views_recent desc

### DIFF
--- a/ckanext/geodatagov/plugin.py
+++ b/ckanext/geodatagov/plugin.py
@@ -418,12 +418,11 @@ class Demo(p.SingletonPlugin):
     def before_dataset_search(self, search_params):
 
         fq = search_params.get('fq', '')
-
         if search_params.get('sort') in (None, 'rank'):
-            search_params['sort'] = 'views_recent desc'
+            search_params['sort'] = 'score desc, views_recent desc'
 
         if search_params.get('sort') in ('none'):
-            search_params['sort'] = 'score desc, name asc'
+            search_params['sort'] = 'score desc, views_recent desc'
 
         # only show collections on bulk update page and when the facet is explictely added
         try:

--- a/ckanext/geodatagov/tests/test_tracking.py
+++ b/ckanext/geodatagov/tests/test_tracking.py
@@ -47,10 +47,9 @@ class TestTracking(object):
         assert cli_result.exit_code == 0
 
         package = helpers.call_action("package_show", id=self.dataset["id"], include_tracking=True)
-        
         assert package['tracking_summary']['total'] == 1
         assert package['tracking_summary']['recent'] == 1
-    
+
     def test_sorting_working_in_package_search(self):
 
         response = helpers.call_action("package_search")

--- a/ckanext/geodatagov/tests/test_tracking.py
+++ b/ckanext/geodatagov/tests/test_tracking.py
@@ -14,41 +14,52 @@ log = logging.getLogger(__name__)
 @pytest.mark.usefixtures("with_plugins")
 class TestTracking(object):
 
-    def create_datasets(self):
-
+    @classmethod
+    def setup_class(cls):
         organization = factories.Organization()
-        self.dataset = factories.Dataset(owner_org=organization["id"])
+        cls.dataset = factories.Dataset(owner_org=organization["id"])
+        cls.dataset2 = factories.Dataset(owner_org=organization["id"])
 
-        # total view should be 0 for a new dataset
-        package = helpers.call_action("package_show", id=self.dataset["id"], include_tracking=True)
-        assert package['tracking_summary']['total'] == 0
-
-        # insert two raw tracking data
+        # insert three raw tracking data with today's date
+        import datetime
+        today = datetime.date.today().isoformat()
         sql = (
             "INSERT INTO tracking_raw (user_key, url, tracking_type, access_timestamp) VALUES"
-            "('aaa','/dataset/{0}','page','2020-10-10'),"
-            "('bbb','/dataset/{0}','page','2021-11-11')"
-        ).format(self.dataset["name"])
+            "('aaa','/dataset/{0}','page','{2}'),"
+            "('bbb','/dataset/{1}','page','{2}'),"
+            "('ccc','/dataset/{1}','page','{2}')"
+        ).format(cls.dataset["name"], cls.dataset2["name"], today)
 
         model.Session.execute(sql)
         model.Session.commit()
 
     @pytest.fixture
     def cli_result(self):
-        self.create_datasets()
-
         runner = CliRunner()
         raw_cli_output = runner.invoke(
             cli.tracking_update,
             args=[],
         )
-
         return raw_cli_output
 
     def test_tracking_data_in_package_show(self, cli_result):
 
         assert cli_result.exit_code == 0
 
-        pacakge = helpers.call_action("package_show", id=self.dataset["id"], include_tracking=True)
-        assert pacakge['tracking_summary']['total'] == 2
-        assert pacakge['tracking_summary']['recent'] == 1
+        package = helpers.call_action("package_show", id=self.dataset["id"], include_tracking=True)
+        
+        assert package['tracking_summary']['total'] == 1
+        assert package['tracking_summary']['recent'] == 1
+    
+    def test_sorting_working_in_package_search(self):
+
+        response = helpers.call_action("package_search")
+
+        # Confirm that the override is working as expected
+        assert response['sort'] == 'score desc, views_recent desc'
+
+        # Confirm the results are in the expected order
+        results = response["results"]
+        print(results)
+        assert results[0]['name'] == self.dataset2['name']
+        assert results[1]['name'] == self.dataset['name']

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="ckanext-geodatagov",
-    version="0.3.2",
+    version="0.3.3",
     description="",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="ckanext-geodatagov",
-    version="0.3.3",
+    version="0.4.0",
     description="",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# Pull Request

Related to https://github.com/GSA/data.gov/issues/5277

## About

This should change the default of relevance to include a secondary sorting of views_recent. When the score (if q is nothing or empty) is all the same, this relevance score comes into effect.

## PR TASKS

- [x] The actual code changes.
- [x] Tests written and passed.
- [x] ~Any changes to docs?~
- [x] Bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/main/setup.py#L13) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).
