### PR TITLE
Exclude collection

### DIFF
--- a/ckanext/geodatagov/helpers.py
+++ b/ckanext/geodatagov/helpers.py
@@ -14,7 +14,7 @@ def count_collection_package(source_id, identifier):
     context = {'model': model, 'session': model.Session}
     package_search = get_action('package_search')
     search_params = {
-        'fq': f'harvest_source_id:{source_id} isPartOf:"{identifier}" include_collection:true',
+        'fq': f'harvest_source_id:{source_id} isPartOf:"{identifier}"',
         'rows': 0,
     }
 

--- a/ckanext/geodatagov/plugin.py
+++ b/ckanext/geodatagov/plugin.py
@@ -424,13 +424,6 @@ class Demo(p.SingletonPlugin):
         if search_params.get('sort') in ('none'):
             search_params['sort'] = 'score desc, views_recent desc'
 
-        try:
-            path = request.path
-        except BaseException:
-            # when there is no requests we get a
-            # TypeError: No object (name: request) has been registered for this thread
-            path = ''
-
         if 'collection_info' in fq:
             # Replace collection_info with harvest_source_id and isPArtOf
             pattern = r'collection_info:"([^"]+?) ([^"]+)"'
@@ -441,7 +434,6 @@ class Demo(p.SingletonPlugin):
         if 'exclude_collection' in fq:
             fq += ' -isPartOf:["" TO *]'
             log.debug('Added FQ to hide collection')
-
 
         # fq comes in as a string such as '(a:1 b:"2" c:["" to *])'
         # remove string exclude_collection=true from fq, if found.

--- a/ckanext/geodatagov/plugin.py
+++ b/ckanext/geodatagov/plugin.py
@@ -4,7 +4,7 @@ import urllib.parse
 import logging
 import mimetypes
 
-from ckan.plugins.toolkit import request, requires_ckan_version
+from ckan.plugins.toolkit import requires_ckan_version
 from ckan.lib.munge import munge_tag
 from ckan import __version__ as ckan_version
 

--- a/ckanext/geodatagov/plugin.py
+++ b/ckanext/geodatagov/plugin.py
@@ -424,7 +424,6 @@ class Demo(p.SingletonPlugin):
         if search_params.get('sort') in ('none'):
             search_params['sort'] = 'score desc, views_recent desc'
 
-        # only show collections on bulk update page and when the facet is explictely added
         try:
             path = request.path
         except BaseException:
@@ -437,19 +436,21 @@ class Demo(p.SingletonPlugin):
             pattern = r'collection_info:"([^"]+?) ([^"]+)"'
             fq = re.sub(pattern, r'harvest_source_id:"\1" isPartOf:"\2"', fq)
             log.debug('FQ changed for collection_info: %s', fq)
-        elif 'bulk_process' not in path and 'include_collection' not in fq:
-            # hide collection's children datasets from regular search
+
+        # hide collections
+        if 'exclude_collection' in fq:
             fq += ' -isPartOf:["" TO *]'
             log.debug('Added FQ to hide collection')
 
+
         # fq comes in as a string such as '(a:1 b:"2" c:["" to *])'
-        # remove string include_collection=true from fq, if found.
-        # Other values of include_collection will end up with a search term that return no results
-        pattern = r'include_collection:"?([^",\s)]+)"?'
+        # remove string exclude_collection=true from fq, if found.
+        # Other values of exclude_collection will end up with a search term that return no results
+        pattern = r'exclude_collection:"?([^",\s)]+)"?'
         match = re.search(pattern, fq, re.IGNORECASE)
         if match and match.group(1).lower() == 'true':
             fq = re.sub(pattern, '', fq, flags=re.IGNORECASE).strip()
-            # if include_collection=true is the only fq, we could end up with a set of parentheses.
+            # if exclude_collection=true is the only fq, we could end up with a set of parentheses.
             if fq == "()":
                 fq = ""
 

--- a/ckanext/geodatagov/tests/test_collections.py
+++ b/ckanext/geodatagov/tests/test_collections.py
@@ -67,10 +67,14 @@ class TestCategoryTags(object):
         assert parent is None
 
         # it is allowed for a dataset to claim itself as the parent, or is it?
-        # just test what is happening now, searching its parent results in itself.
+        # just test what is happening now, searching its parent results in itself
         collection_info = f"{self.datasets['child6']['source_id']} {self.datasets['child6']['isPartOf']}"
         parent = get_collection_package(collection_info)
-        assert next((item["value"] for item in parent['extras'] if item["key"] == "identifier"), None) == self.datasets['child6']['identifier']
+        identifier = next(
+            (item["value"] for item in parent['extras'] if item["key"] == "identifier"),
+            None
+        )
+        assert identifier == self.datasets['child6']['identifier']
 
         # collection_info="source-id parent-id" works. can find two children datasets with collection_info.
         all_children = call_action(

--- a/ckanext/geodatagov/tests/test_collections.py
+++ b/ckanext/geodatagov/tests/test_collections.py
@@ -28,7 +28,8 @@ class TestCategoryTags(object):
             'child2': {'source_id': self.SOURCE_ID, 'identifier': 'child2-id', 'isPartOf': self.PARENT_ID},
             'child3': {'source_id': self.SOURCE_ID, 'identifier': 'child3-id', 'isPartOf': 'parent-id-not'},
             'child4': {'source_id': 'not-this-source', 'identifier': 'child4-id', 'isPartOf': self.PARENT_ID},
-            'child5': {'source_id': 'source:with:colon', 'identifier': 'id:with:colon', 'isPartOf': 'id:with:colon'},
+            'child5': {'source_id': 'some-source-5', 'identifier': 'id:with:colon', 'isPartOf': 'id:with:colon-anther'},
+            'child6': {'source_id': 'some-source-6', 'identifier': 'id-itself', 'isPartOf': 'id-itself'},
         }
 
         for dataset in self.datasets.values():
@@ -65,6 +66,12 @@ class TestCategoryTags(object):
         parent = get_collection_package(collection_info)
         assert parent is None
 
+        # it is allowed for a dataset to claim itself as the parent, or is it?
+        # just test what is happening now, searching its parent results in itself.
+        collection_info = f"{self.datasets['child6']['source_id']} {self.datasets['child6']['isPartOf']}"
+        parent = get_collection_package(collection_info)
+        assert next((item["value"] for item in parent['extras'] if item["key"] == "identifier"), None) == self.datasets['child6']['identifier']
+
         # collection_info="source-id parent-id" works. can find two children datasets with collection_info.
         all_children = call_action(
             'package_search',
@@ -81,16 +88,16 @@ class TestCategoryTags(object):
 
         assert dataset_identifiers == {'child1-id', 'child2-id'}
 
-        # toggle include_collection=true to have children datasets show or hide from search
+        # toggle exclude_collection=true to have children datasets show or hide from search
         all_dataset = call_action(
             'package_search',
             q='*:*',
         )
-        assert all_dataset['count'] == 1
+        assert all_dataset['count'] == len(self.datasets)
 
-        all_dataset_include_collection = call_action(
+        dataset_exclude_collection = call_action(
             'package_search',
             q='*:*',
-            fq='include_collection:true',
+            fq='exclude_collection:true',
         )
-        assert all_dataset_include_collection['count'] == len(self.datasets)
+        assert dataset_exclude_collection['count'] == 1

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="ckanext-geodatagov",
-    version="0.4.0",
+    version="0.4.1",
     description="",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# Pull Request

Related to
- https://github.com/GSA/data.gov/issues/5407

## About

Part of change to make collection children dataset show up in search results
- instead of hiding collection datasets by default, now we show them
- user still can hide the collection datasets by using `exclude_collection=true` on the UI and API call
- add test
- not related but add a new test to show that a dataset can use its identifier as isPartof value, claiming it is its own parent.

## PR TASKS

- [ ] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/main/setup.py#L13) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).
