### PR TITLE
text change for allowing deleted collection

### DIFF
--- a/ckanext/geodatagov/templates/package/read.html
+++ b/ckanext/geodatagov/templates/package/read.html
@@ -33,11 +33,11 @@
     {% if collection_package %}
         <p>{{ _('This dataset is part of the following collection:') }}</p>
         <ul class="dataset-list unstyled">
-            {% snippet "snippets/package_item.html", package=collection_package, is_collection=true, truncate=75 %}
+            {% snippet "snippets/package_item.html", package=collection_package, truncate=75 %}
         </ul>
     {% else %}
-        <p>{{ _('This dataset is part of a deleted collection.') }}</p>
-        <p><a href="{{ h.url_for('search', collection_info=collection_info) }}" class="btn-collection">{{ _('Search other datasets within the same collection') }}</a></p>
+        <p>{{ _('This dataset is part of a collection.') }}</p>
+        <p><a href="{{ h.url_for('search', collection_info=collection_info) }}" class="btn-collection">{{ _('Search datasets within the same collection') }}</a></p>
     {% endif %}
     {% endif %}
 </section>

--- a/ckanext/geodatagov/templates/snippets/related_collection.html
+++ b/ckanext/geodatagov/templates/snippets/related_collection.html
@@ -7,7 +7,7 @@
     <div class="{{ wrapper_class }}">
       <h3>{{ title }}</h3>
       <ul class="dataset-list unstyled">
-        {% snippet "snippets/package_item.html", package=collection_package, is_collection=true%}
+        {% snippet "snippets/package_item.html", package=collection_package %}
       </ul>
     </div>
   </div>


### PR DESCRIPTION
# Pull Request

Related to
- https://github.com/GSA/data.gov/issues/5458

## About

- remove `is_collection`. It was used to add collection label. No need for the label anymore
- some wording change.

## PR TASKS

- [ ] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/main/setup.py#L13) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).
